### PR TITLE
ThingSet specification v0.4

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -14,8 +14,8 @@ BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})
 # adjust link/directory settings in vuepress
 if [ $BRANCH_NAME != "main" ]; then
     printf "\nPreparing deployment for branch $BRANCH_NAME\n"
-    sed -i -e "s/base: '\/'/base: '\/branch\/$BRANCH_NAME\/'/g" docs/.vuepress/config.js
-    sed -i -e "s/docsBranch: 'master'/docsBranch: '$BRANCH_NAME'/g" docs/.vuepress/config.js
+    sed -i -e "s/base: '\/thingset\/'/base: '\/thingset\/branch\/$BRANCH_NAME\/'/g" docs/.vuepress/config.js
+    sed -i -e "s/docsBranch: 'main'/docsBranch: '$BRANCH_NAME'/g" docs/.vuepress/config.js
 else
     printf "\nPreparing deployment for main branch\n"
 fi

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -25,7 +25,8 @@ module.exports = {
                 text: 'History',
                 ariaLabel: 'History Menu',
                 items: [
-                    { text: 'v0.3', link: '/' },
+                    { text: 'v0.4', link: '/' },
+                    { text: 'v0.3', link: '/v0.3/' },
                     { text: 'v0.2', link: '/v0.2/' },
                     { text: 'v0.1', link: '/v0.1/' }
                 ]
@@ -62,7 +63,48 @@ module.exports = {
                     ]
                 }
             ],
-            '/': [  // v0.3 (must be defined at the end as fallback)
+            '/v0.3/': [
+                {
+                    title: 'Why ThingSet?',
+                    collapsable: false,
+                    children: [
+                        '',
+                        '1b_existing_solutions'
+                    ]
+                },{
+                    title: 'Application Layer',
+                    collapsable: false,
+                    children: [
+                        '2a_general',
+                        '2b_text_mode',
+                        '2c_binary_mode',
+                    ]
+                },{
+                    title: 'Lower Layers',
+                    collapsable: false,
+                    children: [
+                        '3a_serial',
+                        '3b_can',
+                        '3c_lorawan'
+                    ]
+                },{
+                    title: 'Protocol Mapping',
+                    collapsable: false,
+                    children: [
+                        '4a_http',
+                        '4b_coap',
+                        '4c_mqtt'
+                    ]
+                },{
+                    title: 'Tools',
+                    collapsable: false,
+                    children: [
+                        '5a_serial',
+                        '5b_can',
+                    ]
+                }
+            ],
+            '/': [  // v0.4 (must be defined at the end as fallback)
                 {
                     title: 'Why ThingSet?',
                     collapsable: false,

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -84,7 +84,7 @@ module.exports = {
                     children: [
                         '3a_serial',
                         '3b_can',
-                        '3c_lora'
+                        '3c_lorawan'
                     ]
                 },{
                     title: 'Protocol Mapping',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -32,72 +32,76 @@ module.exports = {
             }
         ],
         sidebar: {
-            '/': [{
-                title: 'Why ThingSet?',
-                collapsable: false,
-                children: [
-                    '',
-                    '1b_existing_solutions'
-                ]
-            },{
-                title: 'Application Layer',
-                collapsable: false,
-                children: [
-                    '2a_general',
-                    '2b_text_mode',
-                    '2c_binary_mode',
-                ]
-            },{
-                title: 'Lower Layers',
-                collapsable: false,
-                children: [
-                    '3a_serial',
-                    '3b_can',
-                    '3c_lora'
-                ]
-            },{
-                title: 'Protocol Mapping',
-                collapsable: false,
-                children: [
-                    '4a_http',
-                    '4b_coap',
-                    '4c_mqtt'
-                ]
-            },{
-                title: 'Tools',
-                collapsable: false,
-                children: [
-                    '5a_serial',
-                    '5b_can',
-                ]
-            }],
-            '/v0.2/': [{
-                title: 'Why ThingSet?',
-                collapsable: false,
-                children: [
-                    '/v0.2/',
-                    '1b_existing_solutions'
-                ]
-            },{
-                title: 'Application Layer',
-                collapsable: false,
-                children: [
-                    '2a_general',
-                    '2b_functions'
-                ]
-            },{
-                title: 'Lower Layers',
-                collapsable: false,
-                children: [
-                    '3a_serial',
-                    '3b_can',
-                    '3c_lora'
-                ]
-            }],
             '/v0.1/': [
                 'general',
                 'functions',
                 'can'
+            ],
+            '/v0.2/': [
+                {
+                    title: 'Why ThingSet?',
+                    collapsable: false,
+                    children: [
+                        '',
+                        '1b_existing_solutions.md'
+                    ]
+                },{
+                    title: 'Application Layer',
+                    collapsable: false,
+                    children: [
+                        '2a_general',
+                        '2b_functions'
+                    ]
+                },{
+                    title: 'Lower Layers',
+                    collapsable: false,
+                    children: [
+                        '3a_serial',
+                        '3b_can',
+                        '3c_lora'
+                    ]
+                }
+            ],
+            '/': [  // v0.3 (must be defined at the end as fallback)
+                {
+                    title: 'Why ThingSet?',
+                    collapsable: false,
+                    children: [
+                        '',
+                        '1b_existing_solutions'
+                    ]
+                },{
+                    title: 'Application Layer',
+                    collapsable: false,
+                    children: [
+                        '2a_general',
+                        '2b_text_mode',
+                        '2c_binary_mode',
+                    ]
+                },{
+                    title: 'Lower Layers',
+                    collapsable: false,
+                    children: [
+                        '3a_serial',
+                        '3b_can',
+                        '3c_lora'
+                    ]
+                },{
+                    title: 'Protocol Mapping',
+                    collapsable: false,
+                    children: [
+                        '4a_http',
+                        '4b_coap',
+                        '4c_mqtt'
+                    ]
+                },{
+                    title: 'Tools',
+                    collapsable: false,
+                    children: [
+                        '5a_serial',
+                        '5b_can',
+                    ]
+                }
             ]
         },
         // if your docs are in a different repo from your main project:

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -151,7 +151,7 @@ module.exports = {
         // if your docs are not at the root of the repo:
         docsDir: 'docs',
         // if your docs are in a specific branch (defaults to 'master'):
-        docsBranch: 'master',
+        docsBranch: 'main',
         // defaults to false, set to true to enable
         editLinks: false,
         // custom text for edit link. Defaults to "Edit this page"

--- a/docs/2a_general.md
+++ b/docs/2a_general.md
@@ -48,15 +48,15 @@ A device may implement both variants of the protocol, but it is also allowed to 
 
 ## Data Structure
 
-All accessible data of a device is [structured as a tree](https://en.wikipedia.org/wiki/Tree_(data_structure)). The nodes of the tree structure are called **data objects** and correspond to the JSON object definition.
+All accessible data of a device is [structured as a tree](https://en.wikipedia.org/wiki/Tree_(data_structure)). The nodes in the tree structure are called **data objects** and correspond to the JSON object definition.
 
 Inner nodes in the structure are used to define the hierarchical structure of the data.
 
-Actual data is stored in the leaf nodes, called **data items**. The data items can contain any kind of measurements (e.g. temperature), device configuration (e.g. setpoint of a controller) or similar information.
+Actual data is stored in leaf nodes, called **data items**. The data items can contain any kind of measurements (e.g. temperature), device configuration (e.g. setpoint of a controller) or similar information.
 
 Each data object in the tree is identified by a numeric ID and a name. The ID can be chosen by the firmware developer. The name is a short case-sensitive ASCII string containing only alphanumeric characters, dots or underscores without any whitespace characters.
 
-The underscore is only used to specify the unit of a data item (also see below). No additional underscore is allowed in the name.
+The underscore is only used to specify the unit of a data item (also see below). No additional underscores are allowed in the name.
 
 A dot is used to identify paths which are used internally by the implementation of the protocol itself (e.g. configuration of publication messages). Other usages of a dot in the data object names is not allowed.
 
@@ -142,9 +142,9 @@ For explanation of the protocol, the following simplified data structure of an M
 }
 ```
 
-The data objects are structured in different groups like `info` and `conf` as described below. By convention, leaf object names use [upper camel case](https://en.wikipedia.org/wiki/Camel_case), inner objects to define a path use lower case names.
+The data objects are structured in different groups like `info` and `conf` as described below. By convention, data items (leaf nodes) use [upper camel case](https://en.wikipedia.org/wiki/Camel_case) for their names, inner objects to define a path use lower case names.
 
-The `rpc` group provides functions that can be called. In order to distinguish functions from a normal data object, executable object names are lower case and prefixed with `x-`.
+The `rpc` group provides functions that can be called. In order to distinguish functions from normal data objects, executable object names are lower case and prefixed with `x-`.
 
 The `.pub` path is used to configure the automatic publication of messages, so it doesn't hold normal data objects. Such internal nodes are prefixed with a `.`, similar to hidden files or folders in computer file systems.
 
@@ -172,7 +172,7 @@ The `rec` data group is used for history-dependent data like error memory, energ
 
 Factory calibration data objects are only accessible for the manufacturer after authentication.
 
-Excecutable data means that they trigger a function call in the device firmware. Child objects of the executable object can be used to define parameters that can be passed to the function.
+Excecutable data means that they trigger a function call in the device firmware. Child objects of the executable object can be used internally to define parameters that can be passed to the function.
 
 Data object IDs are stored as unsigned integers. The firmware developer should assign the lowest IDs to the most used data objects, as they consume less bytes during transfer (see CBOR representation of unsigned integers).
 
@@ -203,9 +203,9 @@ Some special characters have to be replaced according to the following table in 
 
 The ThingSet protocol aims at being suitable for all classes.
 
-For class 0 devices and on networks with very low bitrate and payload sizes (CAN, LoRaWAN) it is recommended to use the binary mode with numeric IDs instead of data node names to keep the messages as compact as possible.
+For class 0 devices and on networks with very low bitrate and payload sizes (CAN, LoRaWAN) it is recommended to use the binary mode with numeric IDs instead of data object names to keep the messages as compact as possible.
 
-If the payload size does not have to be optimized to its very minimum, the binary mode can be used with names instead of IDs (see [Binary mode](2c_binary_mode.md) chapter for more details). The advantage of the binary mode is that no support for floating point numbers for `printf` is required, which reduces firmware footprint significantly. This mode is suitable for class 0 and class 1 devices.
+If the payload size does not have to be optimized to its very minimum, the binary mode can be used with names instead of IDs (see [Binary Mode](2c_binary_mode.md) chapter for more details). The advantage of the binary mode is that no support for floating point numbers for `printf` is required, which reduces firmware footprint significantly. This mode is suitable for class 0 and class 1 devices.
 
 For most class 1 and class 2 devices, floating-point support will not be an issue, so they might also use the text mode for easier direct interactions with humans. Also gateways should typically support the text mode in order to map ThingSet to other higher-level protocols like HTTP and MQTT.
 
@@ -215,7 +215,7 @@ The first byte of a ThingSet message is either a text-mode identifier ('?', '=',
 
 ### Requests
 
-The protocol supports the typical [CRUD operations](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete). Request codes match with CoAP to allow transparent translation and routing between ThingSet and HTTP APIs or CoAP devices.
+The protocol supports the typical [CRUD operations](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete). Request codes match with CoAP to allow transparent mapping between ThingSet and HTTP APIs or CoAP devices.
 
 | Code | Text ID | Method | Description                                    |
 |------|---------|--------|------------------------------------------------|
@@ -264,9 +264,9 @@ Statements are neither requests nor response messages, as they are sent without 
 |------|---------|---------------------|
 | 0x1F | #       | Statement message   |
 
-The internal path `.pub` is used to configure the device to publish certain data objects on a regular basis through a defined communication channel (UART, CAN, LoRaWAN, etc.). If implemented in the firmware, the publication interval may be adjustable.
+The internal path `.pub` is used to configure the device to publish certain data items on a regular basis through a defined communication channel (UART, CAN, LoRaWAN, etc.). If implemented in the firmware, the publication interval may be adjustable.
 
-By convention, the object names below the `.pub` define which data object should be published. This can be an entire group like `meas` or a data object that contains a list of links to other data objects like `std` in the above example.
+By convention, the object names below the `.pub` define which data object should be published. This can be an entire group like `meas` or a subset data object that contains a list of references to other data items like `report` in the above example.
 
 If a `Period_s` data object exists, it can be set to `0` to disable publication of this message. For event-based publication, a data object `OnChange` can be specified, which publishes the message only if one of the data objects has changed.
 

--- a/docs/2a_general.md
+++ b/docs/2a_general.md
@@ -148,7 +148,7 @@ The `rpc` group provides functions that can be called. In order to distinguish f
 
 The `.pub` path is used to configure the automatic publication of messages, so it doesn't hold normal data objects. Such internal nodes are prefixed with a `.`, similar to hidden files or folders in computer file systems.
 
-The data node `report` in above example is a so-called **data set**, which contains an array pointing at existing data items. It can be used to configure the content of statements for publication if data objects of different groups should be combined in a single message.
+The data node `report` in above example is a so-called **subset**, which contains an array pointing at existing data items. It can be used to configure the content of statements for publication if data objects of different groups should be combined in a single message.
 
 ### Groups
 

--- a/docs/2a_general.md
+++ b/docs/2a_general.md
@@ -52,7 +52,11 @@ All accessible data of a device is [structured as a tree](https://en.wikipedia.o
 
 Inner nodes in the structure are used to define paths or endpoints for data access. Actual data is stored in the leaf nodes, which can contain any kind of measurements (e.g. temperature), device configuration (e.g. setpoint of a controller) or similar information.
 
-Each data object in the tree is identified by a unique ID and a name. The ID can be chosen by the firmware developer. The name is a short case-sensitive ASCII string containing only alphanumeric characters, dots, underscores or dashes without any whitespace characters. The underscore is only used to specify the unit of the data object (if applicable, also see below). No additional underscore is allowed in the name and the name of each object must be unique per device.
+Each data object in the tree is identified by a unique ID and a name. The ID can be chosen by the firmware developer. The name is a short case-sensitive ASCII string containing only alphanumeric characters, dots or underscores without any whitespace characters.
+
+The underscore is only used to specify the unit of the data object (if applicable, also see below). No additional underscore is allowed in the name and the name of each object must be unique per device.
+
+A dot is used to identify paths which are used internally by the implementation of the protocol itself (e.g. configuration of publication messages). Other usages of a dot in the data object names is not allowed.
 
 The numeric IDs are used to access data objects in the binary protocol for reduced message size. They can also be used in the firmware to define the relations in the data structure. For all interactions with users and in the text-based mode, only the object names and paths are used.
 
@@ -184,7 +188,7 @@ Some special characters have to be replaced according to the following table in 
 |-----------|-------------|----------------------------------------------|
 | °         | deg         | "Ambient_degC" for ambient temperature in °C |
 | %         | pct         | "Humidity_pct" for relative humidity in %    |
-| /         | -           | "Veh_m-s" for vehicle speed in m/s           |
+| /         | _           | "Veh_m_s" for vehicle speed in m/s           |
 | ^         | (omitted)   | "Surface_m2" for surface area in m^2         |
 
 ## Device Classes

--- a/docs/2a_general.md
+++ b/docs/2a_general.md
@@ -6,27 +6,35 @@ The ThingSet protocol provides a consistent, standardized way to configure, moni
 
 The underlying layers have to ensure encryption, reliable transfer, correct packet order (if messages are packetized) and error-checking of the transferred data.
 
-A major feature of the ThingSet protocol is a seamless integration with other application layer protocols such as HTTP and [CoAP](https://tools.ietf.org/html/rfc7252). Suggestions for implementing gateways to convert between ThingSet messages and HTTP/CoAP payload will be added in a future separate chapter.
+A major feature of the ThingSet protocol is a seamless integration with other application layer protocols such as HTTP, [CoAP](https://tools.ietf.org/html/rfc7252) and MQTT. Suggestions for implementing gateways to convert between ThingSet messages and HTTP/CoAP/MQTT payload can be found in the Protocol Mapping sections.
 
 ## Message Types
 
-ThingSet defines three types of messages: Requests, responses and publication messages.
+ThingSet defines three types of messages: Requests, responses and statements.
 
-### Request/response or client/server model
+A **request** is sent from one device (client) to a single other device (server). The server is expected to answer with a **response** containing a status code and optional payload.
 
-The communication between two specific devices uses a request/response messaging pattern. A connection can be established either directly (e.g. serial interface, USB, Bluetooth) or via a network or bus with several devices attached (e.g. CAN, Ethernet, WiFi, LoRa). In case of a network, each device has to be uniquely addressable.
+A **statement** is a message that is sent without expecting a response or confirmation. It may be sent to a particular device or broadcast through the network to be received by any interested device (publish-subscribe model).
+
+If a device receives a statement, it is considered a proposal to update the values as stated in the message. If all or some of the requested changes are invalid, they are silently ignored, as it is not possible to respond to a statement.
+
+### Request-response model
+
+The communication between two specific devices uses a request-response messaging pattern. A connection can be established either directly (e.g. serial interface, USB, Bluetooth) or via a network or bus with several devices attached (e.g. CAN, Ethernet, WiFi, LoRa). In case of a network, each device has to be uniquely addressable.
 
 ![Communication Channels](./images/communication_channels.png)
 
-The device acts as the server and responds to the requests by a client. The client might be a display, a mobile phone application or a gateway.
+The client would usually be a display, a mobile phone application or a gateway.
 
-The data transfer is always synchronous: The client sends a request, waits for the response (status code and requested data), processes the response and possibly starts with additional requests.
+The data transfer is always synchronous: The client sends a request and waits until it receives a response before it sends another request to the same device.
 
-### Publication messages
+### Publish-subscribe model
 
-Monitoring data is not intended for only a single device, but could be interesting for several devices (e.g. data logger and display). Thus, the monitoring data can be exchanged via a publish/subscribe messaging pattern.
+Monitoring data is not intended for only a single device, but could be interesting for several devices (e.g. data logger and display). Thus, the monitoring data can be exchanged via a publish-subscribe messaging pattern to increase efficiency and avoid polling.
 
-Publication messages are directly broadcast through the network. Unlike in MQTT, there is no intermediate broker to store the messages and published messages are not confirmed by recipients, so there is no guarantee if the message was received.
+In contrast to MQTT, published messages are directly broadcast and there is no intermediate broker to store the messages. Published messages are not confirmed by recipients, so there is no guarantee if the message was received.
+
+This model is mainly used for machine-to-machine (M2M) communication, e.g. to store measurements in a database. One dedicated application is the plug-and-play control of multiple energy sources and sinks in a renewable energy system. The details of the implementation are currently still work-in-progress.
 
 ## Protocol Modes
 
@@ -34,19 +42,34 @@ Similar to Modbus, the ThingSet protocol supports two different modes: A human-r
 
 In the text mode, payload data is encoded in JSON format ([RFC 8259](https://tools.ietf.org/html/rfc8259)). This mode is recommended when using serial communication interfaces as the low layer protocol, as it can be easily used directly on a terminal.
 
-The binary mode uses the CBOR ([RFC 7049](https://tools.ietf.org/html/rfc7049)) instead of JSON for payload data encoding in order to reduce the protocol overhead for ressource-constrained devices or low bandwith communication protocols like CAN and LoRa.
+The binary mode uses CBOR ([RFC 7049](https://tools.ietf.org/html/rfc7049)) instead of JSON for payload data encoding in order to reduce the protocol overhead for ressource-constrained devices or low bandwith communication via CAN or LoRa.
 
 A device may implement both variants of the protocol, but it is also allowed to support only the mode most suitable for the application.
 
 ## Data Structure
 
-All accessible data of a device is [structured as a tree](https://en.wikipedia.org/wiki/Tree_(data_structure)). The nodes of the tree structure are called data objects in this specification and correspond to the JSON object definition.
+All accessible data of a device is [structured as a tree](https://en.wikipedia.org/wiki/Tree_(data_structure)). The nodes of the tree structure are called data objects and correspond to the JSON object definition.
 
-Internal data objects are used to define paths or endpoints for data access. Actual data is stored in the leaf data object, which can contain any kind of measurements (e.g. temperature), device configuration (e.g. setpoint of a controller) or similar information.
+Inner nodes in the structure are used to define paths or endpoints for data access. Actual data is stored in the leaf nodes, which can contain any kind of measurements (e.g. temperature), device configuration (e.g. setpoint of a controller) or similar information.
 
-Each data object in the tree is identified by a unique ID and a name. The ID can be chosen by the firmware developer. The name is a short case-sensitive ASCII string containing only alphanumeric characters, underscores or dashes without any whitespace characters. The underscore is only used to specify the unit of the data object (if applicable, also see below). No additional underscore is allowed in the name and the name should be unique per device at least for data objects that are used in publication messages.
+Each data object in the tree is identified by a unique ID and a name. The ID can be chosen by the firmware developer. The name is a short case-sensitive ASCII string containing only alphanumeric characters, dots, underscores or dashes without any whitespace characters. The underscore is only used to specify the unit of the data object (if applicable, also see below). No additional underscore is allowed in the name and the name of each object must be unique per device.
 
-The numeric IDs are used to define the relations in the data structure and to directly access data objects in the binary protocol for reduced message size. For all interactions with users and in the text-based mode, only the object names and paths are used.
+The numeric IDs are used to access data objects in the binary protocol for reduced message size. They can also be used in the firmware to define the relations in the data structure. For all interactions with users and in the text-based mode, only the object names and paths are used.
+
+### Reserved IDs
+
+The IDs 0x10-0x1F are reserved for special data objects that need to be known in advance. In addition to that, IDs starting from 0x8000 are reserved for control purposes and will be assigned in the future.
+
+The following table shows the assigned IDs. Currently unassigned IDs might be defined in a future version of the protocol.
+
+| ID   | Name       | Description |
+|------|------------|-------------|
+| 0x10 | Time_s     | Unix timestamp in seconds since Jan 01, 1970 |
+| 0x17 | .name      | Endpoint used by binary protocol to determine names from IDs |
+| 0x18 | DataExtURL | URL to JSON file containing additional information about exposed data |
+| >=0x8000 | ...    | Control data objects with fixed IDs |
+
+The IDs up to 0x17 consume only a single byte when encoded as CBOR, which minimizes space consumption for IDs that are used often. The `DataExtURL` is retrieved only once during startup, so it is acceptable to consume 2 bytes for its ID.
 
 ### Example
 
@@ -54,77 +77,94 @@ For explanation of the protocol, the following simplified data structure of an M
 
 ```JSON
 {
-    "info": {
-        "DeviceType": "MPPT 1210 HUS"
+    "info": {                                                       // 0x01
+        "DataExtURL": "https://files.libre.solar/tsx/cc-v03.json",  // 0x18 (fixed)
+        "DeviceType": "MPPT 1210 HUS",                              // 0x30
+        "DeviceID": "ABC12345"                                      // 0x31
     },
-    "conf": {                                       // data stored in NVM
-        "BatCharging_V": 14.4
+    "meas": {                                                       // 0x02
+        "Time_s": 460677600,                                        // 0x10 (fixed)
+        "Bat_V": 14.2,                                              // 0x40
+        "Bat_A": 5.13,                                              // 0x41
+        "Ambient_degC": 22                                          // 0x42
     },
-    "input": {                                      // data stored in RAM
-        "EnableCharging": true
+    "state": {                                                      // 0x03
+        "ChargerState": 3,                                          // 0x60
+        "ErrorFlags": 0                                             // 0x61
     },
-    "output": {
-        "Bat_V": 14.1,
-        "Bat_A": 5.13,
-        "Ambient_degC": 22
+    "rec": {                                                        // 0x04
+        "BatChgDay_Wh": 1984,                                       // 0x70
+        "AmbientMax_deg": 21.6                                      // 0x71
     },
-    "rec": {
-        "BatChgDay_Wh": 1984
+    "input": {                                                      // 0x05
+        "EnableCharging": true                                      // 0x90
     },
-    "exec": {
-        "reset": null                               // void function
+    "conf": {                                                       // 0x06
+        "BatCharging_V": 14.4                                       // 0xA0
     },
-    "auth": ["Password"],                           // function with 1 parameter
-    "pub": {                                        // publication channels
-        "serial": {
-            "Enable": true,
-            "Interval": 1.0,
-            "IDs": ["Bat_V", "Bat_A"]               // array of object names
-        },
-        "can": {
-            "Enable": false,
-            "Interval_s": 0.1,
-            "IDs": ["Bat_V"]
-        },
-        "mqtt": {
-            "Enable": true,
-            "Interval_s": 3600,
-            "Topic": "chargers/device-id/pub",
-            "IDs": ["Bat_V", "Bat_A"]
+    "rpc": {                                                        // 0x0E
+        "x-reset": null,                                            // 0xE0
+        "x-auth": ["Password"]                                      // 0xE1
+    },
+    "dfu": {                                                        // 0x0D
+        "x-write": ["Offset_B", "Data"],                            // 0xF0
+        "FlashSize_KiB": 128                                        // 0xF1
+    },
+    "report": {                                                     // 0x0A
+        "std": ["Time_s", "Bat_V", "Ambient_degC"],                 // 0x20
+        "slow": ["BatChgDay_Wh"]                                    // 0x21
+    },
+    "ctrl": {                                                       // 0x0C
+        "bus-voltage": {                                            // 0xDC01
+            "Margin_V": 0.7,                                        // 0x7000
+            "AbsMax_v": 30                                          // 0x7001
         }
     },
-    "sub": {                                        // subscription channels
-        "mqtt": {                                   // may have callback attached
-            "Topic": "chargers/device-id/sub",
-            "IDs": ["EnableCharging"]
+    ".pub": {                                                       // 0x0F
+        "info": {                                                   // 0x100
+            "OnChange": true                                        // 0x101
+        },
+        "std": {                                                    // 0x102
+            "Period_s": 10                                          // 0x103
+        },
+        "slow": {                                                   // 0x102
+            "Period_h": 24                                          // 0x103
         }
-    }
+    },
+    ".name": {                                                      // 0x17 (fixed)
+        "1": ".spec",
+        "2": "info",
+        // ...
+        "70": "Bat_V"
+    },
 }
 ```
 
-The data objects are structured in the main different categories info, conf, input, output and rec. By convention, leaf object names use [upper camel case](https://en.wikipedia.org/wiki/Camel_case), inner objects to define a path use lower case names.
+The data objects are structured in different categories like `info` and `conf` as described below. By convention, leaf object names use [upper camel case](https://en.wikipedia.org/wiki/Camel_case), inner objects to define a path use lower case names.
 
-The exec category is special, as it provides functions that can be called. In order to distinguish functions from a normal data object, executable object names are lower case.
+The rpc category is special, as it provides functions that can be called. In order to distinguish functions from a normal data object, executable object names are lower case and prefixed with `x-`.
 
-The pub path is used to configure different types of publication messages, so it doesn't hold normal data objects.
+The `.pub` path is used to configure the automatic publication of messages, so it doesn't hold normal data objects. Such internal nodes are prefixed with a `.`, similar to hidden files or folders in computer file systems.
 
 ### Categories
 
 The following categories for data objects are used for the ThingSet protocol by default:
 
-| Category | Description | Access  |
-|----------|-------------|---------|
-| info     | Device information (e.g. manufacturer, software version) | read access |
-| conf     | Configurable settings, stored in non-volatile memory after change | read/write access, expert settings may be password-protected |
-| input    | Input objects (e.g. actuators) | write access |
-| output   | Output objects (e.g. sensor data) | read access |
-| rec      | Recorded (history-dependent) data (e.g. min/max values) | read access, restricted write access to reset |
-| cal      | Factory-calibrated settings | read/write access, protected
-| exec     | Executable functions | partly access restricted |
+| Category | ID   | Origin | Description | Access |
+|----------|------|-------|-------------|---------|
+| info     | 0x01 | device | Static device information (e.g. manufacturer, software version) | read |
+| meas     | 0x02 | device | Measurement data (changes regularly) | read |
+| state    | 0x03 | device | Event-based status information | read |
+| rec      | 0x04 | device | Recorded (history-dependent) data (e.g. min/max values) | read + reset |
+| input    | 0x05 | client | Input objects (e.g. actuators) | write |
+| conf     | 0x06 | both   | Configurable settings, stored in non-volatile memory after change | read + write, partly protected |
+| cal      | 0x07 | both   | Factory-calibrated settings | read + write, protected |
+| rpc      | 0x0E | client | Executable functions | execute |
+| dfu      | 0x0D | client | Functions and data for device firmware upgrade | read + execute |
 
-The data objects of input and output categories are used for instantaneous data. Changes to input data objects are only stored in RAM, so they get lost after a reset of the device. In contrast to that, conf data is stored in non-volatile memory (e.g. flash or EEPROM) after a change. As non-volatile memory has a limited amount of write cycles, configuration data should not be changed continously.
+The data objects of `meas`, `state` and `input` categories are used for instantaneous data. Changes to `input` data objects are only stored in RAM, so they get lost after a reset of the device. In contrast to that, `conf` data is stored in non-volatile memory (e.g. flash or EEPROM) after a change. As non-volatile memory has a limited amount of write cycles, configuration data should not be changed continuously.
 
-The recorded data category is used for history-dependent data like error memory, energy counters or min/max values of certain measurements. In contrast to data of output category, recorded data cannot be obtained through measurement after reset, so the current state has to be stored in non-volatile memory on a regular basis.
+The `rec` data category is used for history-dependent data like error memory, energy counters or min/max values of certain measurements. In contrast to data of `meas` category, recorded data cannot be obtained through measurement after reset, so the current status has to be stored in non-volatile memory on a regular basis.
 
 Factory calibration data objects are only accessible for the manufacturer after authentication.
 
@@ -146,6 +186,24 @@ Some special characters have to be replaced according to the following table in 
 | %         | pct         | "Humidity_pct" for relative humidity in %    |
 | /         | -           | "Veh_m-s" for vehicle speed in m/s           |
 | ^         | (omitted)   | "Surface_m2" for surface area in m^2         |
+
+## Device Classes
+
+[RFC 7228](https://datatracker.ietf.org/doc/html/rfc7228) defines three different classes of constrained devices according to the following table:
+
+| Name        | data size (e.g., RAM) | code size (e.g., Flash) |
+|-------------|-----------------------|-------------------------|
+| Class 0, C0 | << 10 KiB             | << 100 KiB              |
+| Class 1, C1 | ~ 10 KiB              | ~ 100 KiB               |
+| Class 2, C2 | ~ 50 KiB              | ~ 250 KiB               |
+
+The ThingSet protocol aims at being suitable for all classes.
+
+For class 0 devices and on networks with very low bitrate and payload sizes (CAN, LoRaWAN) it is recommended to use the binary mode with numeric IDs instead of data node names to keep the messages as compact as possible.
+
+If the payload size does not have to be optimized to its very minimum, the binary mode can be used with names instead of IDs (see [Binary mode](2c_binary_mode.md) chapter for more details). The advantage of the binary mode is that no support for floating point numbers for `printf` is required, which reduces firmware footprint significantly. This mode is suitable for class 0 and class 1 devices.
+
+For most class 1 and class 2 devices, floating-point support will not be an issue, so they might also use the text mode for easier direct interactions with humans. Also gateways should typically support the text mode in order to map ThingSet to other higher-level protocols like HTTP and MQTT.
 
 ## Function Codes
 
@@ -194,12 +252,18 @@ The status codes are again aligned with CoAP response codes, but contain an offs
 
 The text mode converts the the hexadecimal response code into a string without the 0x prefix. The binary mode uses the code directly as the first byte.
 
-### Publication messages
+### Statements
 
-Publication messages are neither requests nor response messages, as they are sent without expecting a confirmation. Below table lists the message specifier in text and binary mode.
+Statements are neither requests nor response messages, as they are sent without expecting a confirmation. Below table lists the message specifier in text and binary mode.
 
 | Code | Text ID | Description         |
 |------|---------|---------------------|
-| 0x1F | #       | Publication message |
+| 0x1F | #       | Statement message   |
+
+The internal path `.pub` is used to configure the device to publish certain data objects on a regular basis through a defined communication channel (UART, CAN, LoRaWAN, etc.). If implemented in the firmware, the publication interval may be adjustable.
+
+By convention, the object names below the `.pub` define which data object should be published. This can be an entire category like `meas` or a data object that contains a list of links to other data objects like `std` in the above example.
+
+If a `Period_s` data object exists, it can be set to `0` to disable publication of this message. For event-based publication, a data object `OnChange` can be specified, which publishes the message only if one of the data objects has changed.
 
 More details regarding the ThingSet protocol methods for data access will be explained in the next chapter.

--- a/docs/2b_text_mode.md
+++ b/docs/2b_text_mode.md
@@ -50,7 +50,7 @@ A statement starts with the hash sign and a path, followed by a whitespace and t
 
     txt-statement = "#" path " " json-object
 
-The path is either a group (e.g. `meas`) or a dedicated object (data set) containing references to other objects as an array (e.g. `report`).
+The path is either a group (e.g. `meas`) or a dedicated object (subset) containing references to other objects as an array (e.g. `report`).
 
 ## Read data
 
@@ -103,7 +103,7 @@ Data of category `conf` will be written into persistent memory, so it is not all
 
 Appends new data to a data object.
 
-**Example 1:** Add "Bat_A" to the `report` data set
+**Example 1:** Add "Bat_A" to the `report` subset
 
     +report "Bat_A"
     :81 Created.
@@ -112,7 +112,7 @@ Appends new data to a data object.
 
 Removes data from an object of array type.
 
-**Example 1:** Remove "Bat_A" from `report` data set
+**Example 1:** Remove "Bat_A" from `report` subset
 
     -report "Bat_A"
     :82 Deleted.
@@ -143,7 +143,7 @@ After successful authentication, the device exposes restricted data objects via 
 
 Published statements are broadcast to all connected devices and no response is sent from devices receiving the message.
 
-**Example 1:** A statement containing the `report` data set, sent out by the device every 10 seconds
+**Example 1:** A statement containing the `report` subset, sent out by the device every 10 seconds
 
     #report {"Time_s":460677600,"Bat_V":14.1,"Bat_A":5.13}
 
@@ -154,9 +154,9 @@ The `.pub` node is used to configure the publication process itself.
     ?.pub/
     :85 Content. ["info","report"]
 
-**Example 3:** Disable publication of `report` data set
+**Example 3:** Disable publication of `report` subset
 
     =.pub/report {"Period_s":0}
     :84 Changed.
 
-If the published object is a list of references to data items (and not a group), the data objects contained in the messages can be configured using POST and DELETE requests to the data object (e.g. `report`) as shown in the examples above.
+If the published object is subset object (and not a group), the data items contained in the messages can be configured using POST and DELETE requests to the data object (e.g. `report`) as shown in the examples above.

--- a/docs/2b_text_mode.md
+++ b/docs/2b_text_mode.md
@@ -46,11 +46,11 @@ The bytes after the dot contain the requested data.
 
 ### Statement
 
-A statement starts with the hash sign and a data node name, followed by a whitespace and the map of actual payload data as name/value pairs.
+A statement starts with the hash sign and a path, followed by a whitespace and the map of actual payload data as name/value pairs.
 
-    txt-statement = "#" object-name " " json-object
+    txt-statement = "#" path " " json-object
 
-The object name is either the parent data object (e.g. `meas`) or a dedicated object containing references to other objects as an array (e.g. `std`).
+The path is either a group (e.g. `meas`) or a dedicated object (data set) containing references to other objects as an array (e.g. `report`).
 
 ## Read data
 
@@ -71,12 +71,12 @@ Note that `.name` is not contained in the list, as it is only available in the b
 **Example 2:** Retrieve all content of meas path (keys + values)
 
     ?meas
-    :85 Content. {"Time_s":460677600,"Bat_V":14.2,"Bat_A":5.13,"Ambient_degC":22}
+    :85 Content. {"Bat_V":14.2,"Bat_A":5.13,"Ambient_degC":22}
 
 **Example 3:** List all sub-objects of meas path as an array
 
     ?meas/
-    :85 Content. ["Time_s","Bat_V","Bat_A","Ambient_degC"]
+    :85 Content. ["Bat_V","Bat_A","Ambient_degC"]
 
 **Example 4:** Retrieve single data object "Bat_V"
 
@@ -103,18 +103,18 @@ Data of category `conf` will be written into persistent memory, so it is not all
 
 Appends new data to a data object.
 
-**Example 1:** Add "Bat_A" to the `std` reports
+**Example 1:** Add "Bat_A" to the `report` data set
 
-    +report/std "Bat_A"
+    +report "Bat_A"
     :81 Created.
 
 ## Delete data
 
 Removes data from an object of array type.
 
-**Example 1:** Remove "Bat_A" from `std` reports
+**Example 1:** Remove "Bat_A" from `report` data set
 
-    -report/std "Bat_A"
+    -report "Bat_A"
     :82 Deleted.
 
 ## Execute function
@@ -139,24 +139,24 @@ Internally, the authentication function is implemented as a data object of exec 
 
 After successful authentication, the device exposes restricted data objects via the normal data access requests. The authentication stays valid until another auth command is received, either without password or with a password that doesn't match.
 
-## Publication messages
+## Published statements
 
-Publication messages are broadcast to all connected devices. No response is sent from devices receiving the message.
+Published statements are broadcast to all connected devices and no response is sent from devices receiving the message.
 
-**Example 1:** The `std` publication message, sent out by the device every 10 seconds
+**Example 1:** A statement containing the `report` data set, sent out by the device every 10 seconds
 
-    #std {"Time_s":460677600,"Bat_V":14.1,"Bat_A":5.13}
+    #report {"Time_s":460677600,"Bat_V":14.1,"Bat_A":5.13}
 
 The `.pub` node is used to configure the publication process itself.
 
 **Example 2:** List all statements available for publication
 
     ?.pub/
-    :85 Content. ["info","std"]
+    :85 Content. ["info","report"]
 
-**Example 3:** Disable `std` publication messages
+**Example 3:** Disable publication of `report` data set
 
-    =.pub/std {"Period_s":0}
+    =.pub/report {"Period_s":0}
     :84 Changed.
 
-If the published object is a list of references to data object (and not a category), the data objects contained in the messages can be configured using POST and DELETE requests to the `report/std` endpoint, as shown in the examples above.
+If the published object is a list of references to data items (and not a group), the data objects contained in the messages can be configured using POST and DELETE requests to the data object (e.g. `report`) as shown in the examples above.

--- a/docs/2b_text_mode.md
+++ b/docs/2b_text_mode.md
@@ -26,7 +26,7 @@ Each request message consists of a first character as the request method identif
 
     node-name = ALPHA / DIGIT / "_" / "-" / "."     ; compatible to URIs (RFC 3986)
 
-The path to access a specific node is a JSON pointer ([RFC 6901](https://tools.ietf.org/html/rfc6901)) without the forward slash at the beginning. The useable characters for node names are further restricted to allow un-escaped usage in URLs.
+The path to access a specific data object is a JSON pointer ([RFC 6901](https://tools.ietf.org/html/rfc6901)) without the forward slash at the beginning. The useable characters for node names are further restricted to allow un-escaped usage in URLs.
 
 ### Response
 
@@ -46,19 +46,19 @@ The bytes after the dot contain the requested data.
 
 ### Publication message
 
-The publication message is very simple and consists of a hash sign and a whitespace at the beginning, followed by a map of data node name/value pairs.
+The publication message is very simple and consists of a hash sign and a whitespace at the beginning, followed by a map of data object name/value pairs.
 
     txt-pubmsg = "# " json-map                      ; publication message
 
 ## Read data
 
-The GET function allows to read all child nodes of the specified path. If a forward slash is appended at the end of the path, only an array with the child node names is returned. Otherwise all content below that path (names and values) is returned.
+The GET function allows to read all child objects of the specified path. If a forward slash is appended at the end of the path, only an array with the child object names is returned. Otherwise all content below that path (names and values) is returned.
 
-The FETCH function allows to retrieve only subset of the child nodes, defined by an array with the node names passed to the function.
+The FETCH function allows to retrieve only subset of the child objects, defined by an array with the object names passed to the function.
 
-Only those data nodes are returned which are at least readable. Thus, the result might differ after authentication.
+Only those data objects are returned which are at least readable. Thus, the result might differ after authentication.
 
-**Example 1:** Discover all child nodes of the root node (i.e. categories)
+**Example 1:** Discover all child objects of the root node (i.e. categories)
 
     ?/
     :85 Content. ["info","conf","input","output","rec","exec","pub"]
@@ -68,19 +68,19 @@ Only those data nodes are returned which are at least readable. Thus, the result
     ?output
     :85 Content. {"Bat_V":14.2,"Bat_A":5.13,"Ambient_degC":22}
 
-**Example 3:** List all sub-nodes of output path as an array
+**Example 3:** List all sub-objects of output path as an array
 
     ?output/
     :85 Content. ["Bat_V","Bat_A","Ambient_degC"]
 
-**Example 4:** Retrieve single data node "Bat_V"
+**Example 4:** Retrieve single data object "Bat_V"
 
     ?output ["Bat_V"]
     :85 Content. [14.2]
 
 ## Update data
 
-Requests to overwrite the value of a data node.
+Requests to overwrite the value of a data object.
 
 Data of category conf will be written into persistent memory, so it is not allowed to change settings periodically. Only data of category input can be changed regularly.
 
@@ -96,7 +96,7 @@ Data of category conf will be written into persistent memory, so it is not allow
 
 ## Create data
 
-Appends new data to a data node.
+Appends new data to a data object.
 
 **Example 1:** Add "Bat_V" to the serial publication channel
 
@@ -105,7 +105,7 @@ Appends new data to a data node.
 
 ## Delete data
 
-Removes data from a node of array type.
+Removes data from an object of array type.
 
 **Example 1:** Remove "Bat_V" from "serial" publication channel
 
@@ -127,12 +127,12 @@ Some of the device parameters like calibration or config settings should be prot
 
 The password is transferred as a plain text string. Encryption has to be provided by lower layers.
 
-Internally, the authentication function is implemented as a data node of exec type.
+Internally, the authentication function is implemented as a data object of exec type.
 
     !auth "mypass"
     :83 Valid.
 
-After successful authentication, the device exposes restricted data nodes via the normal data access requests. The authentication stays valid until another auth command is received, either without password or with a password that doesn't match.
+After successful authentication, the device exposes restricted data objects via the normal data access requests. The authentication stays valid until another auth command is received, either without password or with a password that doesn't match.
 
 ## Publication messages
 
@@ -154,4 +154,4 @@ With this setting, the following message is automatically sent by the device onc
 
 Publication messages are broadcast to all connected devices. No response is sent from devices receiving the message.
 
-The data nodes to be published via one channel (e.g. serial) can be configured using POST and DELETE requests to the pub/serial/IDs endpoint, as shown in the examples above.
+The data objects to be published via one channel (e.g. serial) can be configured using POST and DELETE requests to the pub/serial/IDs endpoint, as shown in the examples above.

--- a/docs/2c_binary_mode.md
+++ b/docs/2c_binary_mode.md
@@ -71,29 +71,15 @@ In contrast to the text mode, the binary mode has a special `".name"` endpoint (
 
 Similar to the text mode, the binary variants of the GET and FETCH functions also allow to read one or more data objects. The objects are identified by their parent object (endpoint of a path) and their ID or their name.
 
-The FETCH function is useful for device discovery, as it can list all childs of an object. Depending on the computing power of the device and the host, the FETCH request can either return only the IDs of the next layer or maps including the values. In order to be compatible to the text mode, it is also possible to retrieve all child objects of a resource as a map of name/value pairs.
+With the GET function it is possible to retrieve all child objects of a resource as a map of name/value pairs.
 
-The binary mode also allows to work only with IDs and no paths or object names to keep message size at a minimum. In order to discover the objects of a device, the host can first query all child IDs of an object (starting with root object of ID 0), afterwards query the names for each ID once and then request the value for any data object on demand.
+The FETCH function is useful for device discovery, as it can list all childs of an object. Depending on the computing power and the network bandwidth, the childs can be requested as IDs or names. In addition to that, the FETCH function can retrieve only a subset of child item values.
 
 ### Using data object names
 
-If the names are used to specify an endpoint, also names are used instead of IDs in the returned results.
+If a path (string containing names) is used to specify an endpoint, also names are used instead of IDs in the returned results.
 
-**Example 1:** Discover all child objects names of the root object
-
-    Request:
-    05                                      # FETCH
-       60                                   # CBOR empty string (root object)
-       F7                                   # CBOR undefined as a wildcard
-
-    Response:
-    85                                      # Content.
-       89                                   # CBOR array (9 elements)
-          64 696E666F                       # CBOR string: "info"
-          64 6D656173                       # CBOR string: "meas"
-           ...
-
-**Example 2:** Retrieve all data of meas path (names + values)
+**Example 1:** Retrieve all data of meas path (names + values)
 
     Request:
     01                                      # GET
@@ -109,6 +95,20 @@ If the names are used to specify an endpoint, also names are used instead of IDs
           6C 416D6269656E745F64656743       # CBOR string: "Ambient_degC"
           16                                # CBOR uint: 22
 
+**Example 2:** Discover all child object names of the root object
+
+    Request:
+    05                                      # FETCH
+       60                                   # CBOR empty string (root object)
+       F7                                   # CBOR undefined as a wildcard
+
+    Response:
+    85                                      # Content.
+       89                                   # CBOR array (9 elements)
+          64 696E666F                       # CBOR string: "info"
+          64 6D656173                       # CBOR string: "meas"
+           ...
+
 **Example 3:** Retrieve value of data object "Bat_V"
 
     Request:
@@ -122,21 +122,7 @@ If the names are used to specify an endpoint, also names are used instead of IDs
 
 ### Using data object IDs
 
-**Example 4:** Discover all child object IDs of the root object
-
-    Request:
-    05                                      # FETCH
-       00                                   # CBOR uint: 0x00 (root object)
-       F7                                   # CBOR undefined as a wildcard
-
-    Response:
-    85                                      # Content.
-       89                                   # CBOR array (9 elements)
-          01                                # CBOR uint: 0x01
-          02                                # CBOR uint: 0x02
-           ...
-
-**Example 5:** Retrieve all data of meas path (IDs + values)
+**Example 4:** Retrieve all data of meas path (IDs + values)
 
     Request:
     01                                      # GET
@@ -152,6 +138,20 @@ If the names are used to specify an endpoint, also names are used instead of IDs
           18 42                             # CBOR uint: 0x42
           16                                # CBOR uint: 22
 
+**Example 5:** Discover all child object IDs of the root object
+
+    Request:
+    05                                      # FETCH
+       00                                   # CBOR uint: 0x00 (root object)
+       F7                                   # CBOR undefined as a wildcard
+
+    Response:
+    85                                      # Content.
+       89                                   # CBOR array (9 elements)
+          01                                # CBOR uint: 0x01
+          02                                # CBOR uint: 0x02
+           ...
+
 **Example 6:** Retrieve value of data object "Bat_V"
 
     Request:
@@ -162,7 +162,7 @@ If the names are used to specify an endpoint, also names are used instead of IDs
     85                                      # Content.
        FA 41633333                          # CBOR float: 14.2
 
-**Example 7:** Retrieve multiple data objects:
+**Example 7:** Retrieve multiple data items:
 
     Request:
     05                                      # FETCH
@@ -213,7 +213,7 @@ If the data type is not supported, an error status code (36) is responded.
 
 Appends new data to a data object in a similar way as in the text mode.
 
-**Example 1:** Add object ID 0x41 (Bat_A) to the `report` data set
+**Example 1:** Add object ID 0x41 (Bat_A) to the `report` subset
 
     Request:
     02                                      # POST
@@ -227,7 +227,7 @@ Appends new data to a data object in a similar way as in the text mode.
 
 Removes data from an object of array type.
 
-**Example 1:** Remove object ID 0x41 (Bat_A) from `report` data set
+**Example 1:** Remove object ID 0x41 (Bat_A) from `report` subset
 
     Request:
     04                                      # DELETE
@@ -257,7 +257,7 @@ Note that the endpoint is the object of the executable function itself. Data can
 
 In contrast to text mode, published statements in binary mode only contain the values and not the corresponding names or IDs in order to reduce payload data as much as possible.
 
-**Example 1:** A statement containing the `report` data set, sent out by the device every 10 seconds
+**Example 1:** A statement containing the `report` subset, sent out by the device every 10 seconds
 
     1F
        18 20                                # CBOR uint: 0x20 (object ID)
@@ -288,7 +288,7 @@ If the name of the object is supplied instead of the ID, also names are returned
 
     Request:
     05                                      # FETCH
-       63 737464                            # CBOR string: "std" (object name)
+       66 7265706F7274                      # CBOR string: "report" (object name)
        F7                                   # CBOR undefined
 
     Response:

--- a/docs/2c_binary_mode.md
+++ b/docs/2c_binary_mode.md
@@ -101,9 +101,7 @@ If the names are used to specify an endpoint, also names are used instead of IDs
 
     Response:
     85                                      # Content.
-       A4                                   # CBOR map (4 elements)
-          66 54696D655F73                   # CBOR string: "Time_s"
-          1A 1B7561E0                       # CBOR uint: 460677600
+       A3                                   # CBOR map (3 elements)
           65 4261745F56                     # CBOR string: "Bat_V"
           FA 41633333                       # CBOR float: 14.2
           65 4261745F41                     # CBOR string: "Bat_A"
@@ -146,9 +144,7 @@ If the names are used to specify an endpoint, also names are used instead of IDs
 
     Response:
     85                                      # Content.
-       A4                                   # CBOR map (4 elements)
-          10                                # CBOR uint: 0x10
-          1A 1B7561E0                       # CBOR uint: 460677600
+       A3                                   # CBOR map (3 elements)
           18 40                             # CBOR uint: 0x40
           FA 41633333                       # CBOR float: 14.2
           18 41                             # CBOR uint: 0x41
@@ -217,7 +213,7 @@ If the data type is not supported, an error status code (36) is responded.
 
 Appends new data to a data object in a similar way as in the text mode.
 
-**Example 1:** Add object ID 0x41 (Bat_A) to the `std` report
+**Example 1:** Add object ID 0x41 (Bat_A) to the `report` data set
 
     Request:
     02                                      # POST
@@ -231,7 +227,7 @@ Appends new data to a data object in a similar way as in the text mode.
 
 Removes data from an object of array type.
 
-**Example 1:** Remove object ID 0x41 (Bat_A) from `std` report
+**Example 1:** Remove object ID 0x41 (Bat_A) from `report` data set
 
     Request:
     04                                      # DELETE
@@ -257,11 +253,11 @@ For execution of a function, the same POST request is used as when creating data
 
 Note that the endpoint is the object of the executable function itself. Data can be passed to the called function as the second parameter, but the "reset" function does not require any parameters, so it receives an empty array.
 
-## Publication messages
+## Published statements
 
-In contrast to text mode, publication messages in binary mode only contain the values and not the corresponding names or IDs in order to reduce payload data as much as possible.
+In contrast to text mode, published statements in binary mode only contain the values and not the corresponding names or IDs in order to reduce payload data as much as possible.
 
-**Example 1:** Publication message `std`
+**Example 1:** A statement containing the `report` data set, sent out by the device every 10 seconds
 
     1F
        18 20                                # CBOR uint: 0x20 (object ID)

--- a/docs/3a_serial.md
+++ b/docs/3a_serial.md
@@ -24,6 +24,8 @@ The CRC checksum is calculated over the entire thingset-msg as defined above. Th
 
 The CRC is optional so that it is still possible to interact with the device by humans using a terminal. However, the device should always calculate the CRC and in case of M2M communication, the client should check the CRC and also provide a CRC for requests to increase reliability.
 
+The baudrate of the serial interface is fixed to 115200 bps.
+
 ::: warning
 The binary protocol mode is curently not supported, as it would require some way to determine the end of a message.
 :::

--- a/docs/3a_serial.md
+++ b/docs/3a_serial.md
@@ -27,7 +27,7 @@ The CRC is optional so that it is still possible to interact with the device by 
 The baudrate of the serial interface is fixed to 115200 bps.
 
 ::: warning
-The binary protocol mode is curently not supported, as it would require some way to determine the end of a message.
+The binary protocol mode is curently not supported via simple serial interfaces, as it would require some way to determine the end of a message.
 :::
 
 ## USB

--- a/docs/3b_can.md
+++ b/docs/3b_can.md
@@ -156,23 +156,23 @@ The publication message provides a very efficient way to send data in a regular 
 
 ### CAN identifier layout
 
-Publication messages are not sent to a single node, so the destination address does not need to be specified. Instead, the data node ID is specified directly in the CAN identifier to have more bytes available for payload in the data section of the CAN frame.
+Publication messages are not sent to a single node, so the destination address does not need to be specified. Instead, the data object ID is specified directly in the CAN identifier to have more bytes available for payload in the data section of the CAN frame.
 
 | Bits | 28 .. 26 | 25 | 24 |   23 .. 16         |   15 .. 8          |   7 .. 0       |
 |------|:--------:|:--:|:--:|:------------------:|:------------------:|:--------------:|
-|      | Priority | 1  | 1  | Data node ID (MSB) | Data node ID (LSB) | Source address |
+|      | Priority | 1  | 1  | Data object ID (MSB) | Data object ID (LSB) | Source address |
 
 - Priority (28-26): Defines the importance of the message. For publication messages, only 4 (high priority), 5 (medium priority) and 6 (low priority) are valid.
 - Extended data page / EDP (25): Always 1b to prevent collision with SAE J1939 and NMEA2000 devices on the same bus
 - Message type (24): 1b for publication message
-- Data node ID (23-8): Data node ID as a 16-bit unsigned integer. The most significant byte is stored first (bits 23 to 16).
+- Data object ID (23-8): Data object ID as a 16-bit unsigned integer. The most significant byte is stored first (bits 23 to 16).
 - Source address (7-0): Source node address (255 for anonymous message during address claiming)
 
-The data node ID is not encoded in the CBOR format, but as a raw 16-bit unsigned integer. The publication messages are limited to IDs that fit into 16 bits.
+The data object ID is not encoded in the CBOR format, but as a raw 16-bit unsigned integer. The publication messages are limited to IDs that fit into 16 bits.
 
 ### CAN data format
 
-The data section of the CAN frame contains the CBOR-encoded value of the data node with the specified ID.
+The data section of the CAN frame contains the CBOR-encoded value of the data object with the specified ID.
 
 In order to acquire real-time measurement values, a 16-bit timestamp (unsigned int) can be appended to the CBOR-encoded value. The timestamp contains the 16 least significant bits of the microcontroller's system clock in milliseconds. It is a rolling counter and restarts at 0 after an overflow. The timestamp cannot be used to determine the absolute time of a measurement, but the time difference between subsequent measurements. This is important to obtain correct sampling of time-series data if higher priority messages cause a delay of the data delivery on the bus.
 

--- a/docs/3b_can.md
+++ b/docs/3b_can.md
@@ -170,6 +170,8 @@ Publication messages are not sent to a single node, so the destination address d
 
 The data object ID is not encoded in the CBOR format, but as a raw 16-bit unsigned integer. The publication messages are limited to IDs that fit into 16 bits.
 
+IDs >= 0x8000 are fixed and reserved for control messages, so the CAN filter can be configured to distinguish between normal data ojbects and (high priority) control messages.
+
 ### CAN data format
 
 The data section of the CAN frame contains the CBOR-encoded value of the data object with the specified ID.

--- a/docs/3c_lorawan.md
+++ b/docs/3c_lorawan.md
@@ -1,8 +1,8 @@
 ---
-title: "LoRa"
+title: "LoRaWAN"
 ---
 
-# ThingSet via LoRa
+# ThingSet via LoRaWAN
 
 As the data rate of LoRa is very low, only the binary protocol version is supported.
 

--- a/docs/3c_lorawan.md
+++ b/docs/3c_lorawan.md
@@ -27,7 +27,7 @@ The following table gives an overview of the LoRaWAN ports as they are planned t
 | Port(s)    | Usage |
 |------------|-------|
 | 0x00       | Reserved for LoRaWAN MAC messages
-| 0x01..0x3F | ThingSet statement values (corresponding to ID of group or data set)
+| 0x01..0x3F | ThingSet statement values (corresponding to ID of group or subset)
 | 0x40       | ThingSet request/response channel
 | 0x41..0x7F | ThingSet statement IDs (corresponding to ID + 0x40)
 | 0x80..0xDF | Reserved for future use in ThingSet

--- a/docs/3c_lorawan.md
+++ b/docs/3c_lorawan.md
@@ -4,6 +4,36 @@ title: "LoRaWAN"
 
 # ThingSet via LoRaWAN
 
+::: warning
+This part of the protocol specification is still work in progress.
+:::
+
 As the data rate of LoRa is very low, only the binary protocol version is supported.
 
-Detailed specification still to be done. Layout might be similar to CAN bus (but CAN has even smaller packet sizes...).
+The ThingSet mapping is optimized for Class A devices, which allow only a very limited amount of downlink messages from the gateway to the device. This means that a request/response model is not suitable over LoRaWAN.
+
+Instead, the communication mainly relies on statements sent from the device to the gateway.
+
+## Port mapping
+
+LoRaWAN supports to specify a so-called port for each message to differentiate between different types of payload. The port can be an integer in the range of 1..223 (0x01..0xDF).
+
+The ports are mapped to the ThingSet data object IDs and only IDs from 0x01..0x3F are used for communication via LoRaWAN.
+
+Only the values are communicated regularly. The corresponding IDs for each statement are sent only once during startup to the port with ID + 0x40.
+
+The following table gives an overview of the LoRaWAN ports as they are planned to be used for ThingSet:
+
+| Port(s)    | Usage |
+|------------|-------|
+| 0x00       | Reserved for LoRaWAN MAC messages
+| 0x01..0x3F | ThingSet statement values (corresponding to ID of group or data set)
+| 0x40       | ThingSet request/response channel
+| 0x41..0x7F | ThingSet statement IDs (corresponding to ID + 0x40)
+| 0x80..0xDF | Reserved for future use in ThingSet
+| 0xE0..0xFF | Reserved for LoRaWAN
+
+## Open questions
+
+- How to transfer data object names?
+- How to transfer device ID?

--- a/docs/4a_http.md
+++ b/docs/4a_http.md
@@ -22,3 +22,31 @@ In order to reduce the complexity of the protocol, the features offered by HTTP 
     - Unit of data objects stored in the name (key) of a map, so the required amount of nesting in the JSON data structure is limited to categories only.
 
 The response codes of ThingSet are aligned with CoAP and thus also allow a simple translation to HTTP. The main difference is that HTTP doesn't allow to indicate successful requests as fine-grained as CoAP, so the status will be mostly 200 OK or 204 No Content.
+
+## Data Processing
+
+### HTTP via CAN
+
+```
+Dev     CAN:txt     GW   HTTP:txt   Web App
+ |                  |                  |
+ |                  |   req objects    |
+ |   req objects    | <--------------- |
+ | <--------------- |                  |
+ |   resp objects   |                  |
+ | ---------------> |   resp objects   |
+ |                  | ---------------> |
+```
+
+### HTTP via Serial
+
+```
+Dev    UART:txt     GW   HTTP:txt   Web App
+ |                  |                  |
+ |                  |   req objects    |
+ |   req objects    | <--------------- |
+ | <--------------- |                  |
+ |   resp objects   |                  |
+ | ---------------> |   resp objects   |
+ |                  | ---------------> |
+```

--- a/docs/4c_mqtt.md
+++ b/docs/4c_mqtt.md
@@ -159,7 +159,7 @@ Dev    UART:txt   GW   HTTP:txt   Web App
 
 #### CAN (smart gateway)
 
-- ID mapping on gateway
+- ID mapping and translation between binary and text mode on gateway
 - Preferred way
 
 ```
@@ -167,8 +167,6 @@ Dev     CAN:bin       GW       MQTT:txt       Broker
  |                    |                         |
  |      values        |                         |
  | -----------------> |                         |
- |    req/resp ids    |                         |
- | <----------------> |                         |
  |   req/resp names   |                         |
  | <----------------> |    objects (QoS 0)      |
  |                    | ----------------------> |
@@ -258,7 +256,7 @@ Dev    UART:txt     GW   MQTT:txt   Web App
 
 #### CAN (direct)
 
-- No mapping of IDs needed, as wishes are sent via ISO-TP and can have almost arbitrary length.
+- No mapping of IDs needed, as incoming statements are sent via ISO-TP and can have almost arbitrary length.
 
 ```
 Dev     CAN:txt      GW       MQTT:txt       Broker

--- a/docs/4c_mqtt.md
+++ b/docs/4c_mqtt.md
@@ -8,18 +8,18 @@ The MQTT protocol doesn't support the request/response part of the ThingSet prot
 
 ## Publication
 
-The topic used to publish to the MQTT server may contain the path of the data nodes. The topic name itself could be stored as a data node, but it's not relevant to the implementation of publication messages in the ThingSet protocool.
+The topic used to publish to the MQTT server may contain the path of the data objects. The topic name itself could be stored as a data object, but it's not relevant to the implementation of publication messages in the ThingSet protocool.
 
 A ThingSet publication message starts with a first byte 0x1F in binary mode or "# " in text mode to indicate a publication message. Whether this byte is also stored in the MQTT topic depends on the application.
 
 If a single measurement value is stored in an MQTT topic (e.g. /devices/device-id/Bat_V for the battery voltage), it is recommended that only the JSON or CBOR payload data is stored in the MQTT payload and the path of the ThingSet endpoint is contained in the topic.
 
-If multiple data nodes are stored in the same topic, the entire ThingSet publication message could be stored to allow direct passing between MQTT topic and ThingSet.
+If multiple data objects are stored in the same topic, the entire ThingSet publication message could be stored to allow direct passing between MQTT topic and ThingSet.
 
 ## Subscription
 
-Content fetched from a specific topic is forwarded to the ThingSet protocol as a publication message. The ThingSet device will parse the incoming data similar to a PATCH request. Unknown data nodes contained in the subscribed payload are silently ignored.
+Content fetched from a specific topic is forwarded to the ThingSet protocol as a publication message. The ThingSet device will parse the incoming data similar to a PATCH request. Unknown data objects contained in the subscribed payload are silently ignored.
 
-If the application requires some processing of incoming data before applying them to actual nodes, temporary data nodes can be created where the subscribed content is written to. Afterwards a function is called (assigned as a callback to the sub channel node) to process the incoming data and pass it on to the actual nodes.
+If the application requires some processing of incoming data before applying them to actual nodes, temporary data objects can be created where the subscribed content is written to. Afterwards a function is called (assigned as a callback to the sub channel node) to process the incoming data and pass it on to the actual nodes.
 
 This approach can also be used to determine if the received data has changed compared to already existing state and avoid too many storage operations in EEPROM for regularly published messages.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This specification describes a communication protocol for control, configuration and monitoring of connected devices. It is published under the permissive [CC BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).
+This specification describes a communication protocol for control, configuration and monitoring of connected devices. It is published under the [CC BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).
 
 The protocol is called ThingSet - a protocol for **set**tings of **thing**s. The main goals of the protocol are:
 
@@ -18,7 +18,7 @@ Similar to Modbus, the protocol should have a text-based mode which is human-rea
 
 ### Compact footprint
 
-Implementation and binary data representations should be very compact to enable transport via LoRa and CAN. Standard CAN frames allow a payload of only 8 bytes per frame, LoRa allows [51 bytes](https://www.thethingsnetwork.org/forum/t/limitations-data-rate-packet-size-30-seconds-uplink-and-10-messages-downlink-per-day-fair-access-policy/1300) of application payload per message.
+Implementation and binary data representations should be very compact to enable transport via LoRa and CAN. Standard CAN frames allow a payload of only 8 bytes per frame, LoRaWAN allows [51 bytes](https://www.thethingsnetwork.org/forum/t/limitations-data-rate-packet-size-30-seconds-uplink-and-10-messages-downlink-per-day-fair-access-policy/1300) of application payload per message.
 
 ### Schema-less and self-explaining
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,20 @@
 # Introduction
 
+::: warning
+This is the new v0.4 specification with the following most important updates compared to v0.3:
+- Nomenclature changes
+  - Data nodes are now called data objects ("node" could be confused with IoT nodes)
+  - Leaf nodes containing actual data are called data items
+- Publication messages are called statements
+- Statements now contain the path (necessary for better integration with MQTT)
+- GET requests in binary mode do not contain any payload anymore to avoid incompatibility with CoAP and HTTP mapping. The FETCH request is used for discovery instead.
+- Executable data objects are prefixed with `x-`
+- Internal data objects (prefixed with `.`) are used to configure publication
+- Draft for MQTT topic layout added
+
+The previous version (as used by older firmware) can be found in the history at the top right corner.
+:::
+
 This specification describes a communication protocol for control, configuration and monitoring of connected devices. It is published under the [CC BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).
 
 The protocol is called ThingSet - a protocol for **set**tings of **thing**s. The main goals of the protocol are:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,18 +1,19 @@
 # Introduction
 
 ::: warning
-This is the new v0.4 specification with the following most important updates compared to v0.3:
+This is the new **v0.4 specification** with the following most important updates compared to v0.3:
+
 - Nomenclature changes
-  - Data nodes are now called data objects ("node" could be confused with IoT nodes)
-  - Leaf nodes containing actual data are called data items
-- Publication messages are called statements
+  - Data nodes are now called **data objects** ("node" could be confused with IoT nodes)
+  - Leaf nodes containing actual data are called **data items**
+  - Publication messages are called **statements**
 - Statements now contain the path (necessary for better integration with MQTT)
 - GET requests in binary mode do not contain any payload anymore to avoid incompatibility with CoAP and HTTP mapping. The FETCH request is used for discovery instead.
 - Executable data objects are prefixed with `x-`
-- Internal data objects (prefixed with `.`) are used to configure publication
-- Draft for MQTT topic layout added
+- Internal data objects (prefixed with `.`) are used to configure publication period, etc.
+- Draft MQTT topic mapping is now part of the spec
 
-The previous version (as used by older firmware) can be found in the history at the top right corner.
+Previous versions as used by older firmware can be found in the history at the top right corner.
 :::
 
 This specification describes a communication protocol for control, configuration and monitoring of connected devices. It is published under the [CC BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).

--- a/docs/v0.3/1b_existing_solutions.md
+++ b/docs/v0.3/1b_existing_solutions.md
@@ -1,0 +1,109 @@
+# Existing Standards
+
+In order to not re-invent the wheel, existing standards were investigated prior to the development of the ThingSet specification.
+
+This chapter gives an overview about the advantages and disadvantages of existing solutions. If you just want to know how ThingSet works, you can move on to the next chapter.
+
+As the ThingSet protocol was originally developed for energy management based on CAN communication, below analysis covers this aspect in more detail.
+
+## Protocols
+
+### Modbus
+
+Modbus RTU and Modbus TCP are quite old, quasi-standard protocols to read and write registers of a device. Modbus requires knowledge of the accessible register addresses and the data format. A method to discover available settings and measurement values is not possible, so it does not fulfill the requirement to be self-describing.
+
+### Firmata
+
+In the Arduino community, a protocol called [Firmata](http://firmata.org/wiki/Main_Page) is very popular to control Arduino devices directly via the serial interface. The protocol based on the MIDI protocol and very compact. However, the approach is very Arduino-specific and targets to remote-control as many Arduino features as possible. ThingSet aims to be a more general purpose solution.
+
+### CANopen and EnergyBus
+
+CANopen is developed by CAN in Automation (CiA). This high level protocol uses CAN as physical layer and adds profile specifications, standardized communication protocol and advanced error handling to the core functionality of CAN. Despite the word "open" in the name, only the basic device profile specifications are open accessible. A paid CiA membership is necessary to access all specifications. Unfortunately, the EnergyBus profiles (CiA 454) for a CAN based energy management system are not provided with free access.
+
+CiA DS301 specifies the basic communication functionalities of the CANopen application layer.
+
+Every device (called CANopen node) must have an object dictionary (OD). This is a large table stored in the node which contains all kinds of data, including device parameters, measurement or control data. In addition to that, it stores also data necessary for communication e.g. which datatypes are used or how a message can be transported (broadcast, handshake, ..).
+
+There are two different types of telegrams:
+
+- Service Data Objects (SDOs): These are only used to access the OD. When a device receives an SDO it changes the values of parameters or other OD table entries. The communication is based on a Client/Server relationship. A client initiates an SDO communication, the server then changes its OD according to the client's instruction and sends a response. The client is typically a master device or an operator who supervises and configures the entire network.
+
+- Process Data Objects (PDOs): The majority of messages in the bus contain process information like measurement data, control data, status data, etc. The data is read from the OD and transmitted as a PDO, which is basically a pure CAN telegram without protocol overhead. The CAN-identifier of a PDO telegram does not only contain the node-ID of a device (like this is the case in "pure CAN") but also what kind of content is delivered by the telegram.
+
+The PDO telegrams are not predefined, but they are configured separately for each network. For each device, four Receive-PDOs (RPDOs) and four Transmit-PDOs (TPDOs) can be defined. For example, the actual current of the battery could be sent as a TPDO by the battery management system and an received as RPDO in a charge controller.
+
+The connection channels between different devices for PDO exchange are defined using a PDO mapping procedure. This has the advantage that the process data exchange between different devices can be very flexible. However, it makes an initial network setup necessary. If a device is added to the network, it has to be shut down, some PDO mappings have to be defined and afterwards the network is put into operation mode again. This contradicts to the requirement of a plug-and-play capable energy system.
+
+An intelligent master device implementing the network management (NMT) features could be used instead of manual configuration. But also a master device is not beneficial for a distributed, fail-safe energy system.
+
+Summary of issues:
+
+- Pre-defined frame layout defined in not completely open specification
+- Complicated network setup (normally done using proprietary tools)
+- Not intended for master-less operation
+- Only 4 RPDOs and TPDOs possible per node ID for control functions
+
+### SAE J1939 / RV-C / NMEA2000 / ISOBUS
+
+The collection of SAE J1939 standards describe a well-established CAN application layer protocol. Several other protocols like RV-C (recreational vehicles), NMEA2000 (marine applications) and ISOBUS (agriculture machines) are based on SAE J1939.
+
+Unfortunately, all SAE J1939 based standards (including the base standard itself) are proprietary and not puplic. Only RV-C is available for download.
+
+SAE J1939 uses only the extended format CAN id with 29 bits and encodes message priority, source ID, destination ID and the type of message (Parameter Group Number, PGN) inside the CAN ID.
+
+In general, SAE J1939 is based on fixed (specified) layout of the data fields in the CAN frame, depending on the PGN.
+
+In addition, the protocol is not designed for configuration of parameters. Writing parameters to a device can be achieved only by specifying special PGNs. In contrast to CANopen, parameters cannot be read or written by default.
+
+### XCP (Universal Measurement and Calibration Protocol)
+
+XCP is an established protocol for ECU (Engine Control Unit) development in the automotive industry. It is not limited to CAN as a low level interface, but CAN is probably the most commonly used lower layer.
+
+Measurement data and calibration parameters are accessed directly via registers in the microcontroller. Thus, the register values and description has to be generated during linking of the binary code. The register description is typically saved in a .A2L file.
+
+For an agile open source based development, the toolchain for generating the A2L file is considered too complicated. In addition to that, tools for XCP and A2L are mostly proprietary and expensive.
+
+XCP is also not useable for a master-less control of devices in a system, as this was not a purpose of the protocol.
+
+However, XCP offers a well-suited way for firmware upgrades of devices. This feature might be adapted in a future version of this specification.
+
+### UAVCAN
+
+[UAVCAN](http://uavcan.org/) is a modern and lightweight protocol based on CAN, also targeting a master-less network. Main applications include aerospace and robotic applications.
+
+The protocol is fully open, well-designed and easy to be implemented. However, it also uses pre-defined messages for the communication between devices.
+
+The node ID assignment process is more complicated compared to SAE J1939.
+
+Some aspects of the UAVCAN protocol might be adapted in the CAN lower layer of this specification.
+
+<!--
+
+## Serialization Formats
+
+Flexible data representation needs serialization.
+
+### Protocol Buffers
+
+This serialization format uses pre-defined schemas for the message layout. It would not be possible to read or write previously unknown data objects or read data objects you did not define a data type for.
+
+Example:
+
+	!read ["var1", "var2"]
+	:0 Success. [1.5, true]
+
+Equivalent in protobuf:
+
+	!read message1
+
+where .proto file defines content of message1 contains one float and one boolean.
+
+Now, if you decide you want to add an additional variable, current thingset concept is like this:
+
+	!read ["var1", "var2", "var3"]
+
+For protobouf you need to define a new message of type message2, which is hard-coded in the device.
+
+Protobuf does not allow to use string identifiers instead of the numbers.
+
+-->

--- a/docs/v0.3/2a_general.md
+++ b/docs/v0.3/2a_general.md
@@ -1,0 +1,203 @@
+# General Concept
+
+The ThingSet protocol provides a consistent, standardized way to configure, monitor and control ressource-constrained devices via different communication interfaces. It specifies the higher layers (5 to 7) of the [OSI (Open Systems Interconnection) model](https://en.wikipedia.org/wiki/OSI_model). The payload data is independent of the underlying lower layer protocol or interface, which can be CAN, USB, LoRa, WiFi, Bluetooth, UART (serial) or similar.
+
+![ISO/OSI layer setup](./../images/osi_layers.png)
+
+The underlying layers have to ensure encryption, reliable transfer, correct packet order (if messages are packetized) and error-checking of the transferred data.
+
+A major feature of the ThingSet protocol is a seamless integration with other application layer protocols such as HTTP and [CoAP](https://tools.ietf.org/html/rfc7252). Suggestions for implementing gateways to convert between ThingSet messages and HTTP/CoAP payload will be added in a future separate chapter.
+
+## Message Types
+
+ThingSet defines three types of messages: Requests, responses and publication messages.
+
+### Request/response or client/server model
+
+The communication between two specific devices uses a request/response messaging pattern. A connection can be established either directly (e.g. serial interface, USB, Bluetooth) or via a network or bus with several devices attached (e.g. CAN, Ethernet, WiFi, LoRa). In case of a network, each device/node has to be uniquely addressable.
+
+![Communication Channels](./../images/communication_channels.png)
+
+The device acts as the server and responds to the requests by a client. The client might be a display, a mobile phone application or a gateway.
+
+The data transfer is always synchronous: The client sends a request, waits for the response (status code and requested data), processes the response and possibly starts with additional requests.
+
+### Publication messages
+
+Monitoring data is not intended for only a single device, but could be interesting for several devices (e.g. data logger and display). Thus, the monitoring data can be exchanged via a publish/subscribe messaging pattern.
+
+Publication messages are directly broadcast through the network. Unlike in MQTT, there is no intermediate broker to store the messages and published messages are not confirmed by recipients, so there is no guarantee if the message was received.
+
+## Protocol Modes
+
+Similar to Modbus, the ThingSet protocol supports two different modes: A human-readable text mode and a binary mode.
+
+In the text mode, payload data is encoded in JSON format ([RFC 8259](https://tools.ietf.org/html/rfc8259)). This mode is recommended when using serial communication interfaces as the low layer protocol, as it can be easily used directly on a terminal.
+
+The binary mode uses the CBOR ([RFC 7049](https://tools.ietf.org/html/rfc7049)) instead of JSON for payload data encoding in order to reduce the protocol overhead for ressource-constrained devices or low bandwith communication protocols like CAN and LoRa.
+
+A device may implement both variants of the protocol, but it is also allowed to support only the mode most suitable for the application.
+
+## Data Structure
+
+All accessible data of a device is [structured as a tree](https://en.wikipedia.org/wiki/Tree_(data_structure)). Internal nodes are used to define paths or endpoints for data access. Actual data is stored in the leaf nodes and can be any kind of measurements (e.g. temperature), device configuration (e.g. setpoint of a controller) or similar information.
+
+Each node is identified by a unique node ID and a name. The ID can be chosen by the firmware developer. The name is a short case-sensitive ASCII string containing only alphanumeric characters, an underscore, dots or dashes without any whitespace characters. The underscore is only used to specify the unit of the data (if applicable, also see below). No additional underscore is allowed in the name and it should be unique per device at least for nodes that are used in publication messages.
+
+The numeric IDs are used to define the relations between nodes and to directly access data nodes in the binary protocol for reduced message size. For all interactions with users and in the text-based mode, only the node names and paths (consisting of multiple node names) are used.
+
+### Example
+
+For explanation of the protocol, the following simplified data structure of an MPPT charge controller will be used:
+
+```JSON
+{
+    "info": {
+        "DeviceType": "MPPT 1210 HUS",
+    },
+    "conf": {                                       // data stored in NVM
+        "BatCharging_V": 14.4,
+    },
+    "input": {                                      // data stored in RAM
+        "EnableCharging": true
+    },
+    "output": {
+        "Bat_V": 14.1,
+        "Bat_A": 5.13,
+        "Ambient_degC": 22
+    },
+    "rec": {
+        "BatChgDay_Wh": 1984,
+    },
+    "exec": {
+        "reset": null,                              // void function
+    },
+    "auth": ["Password"],                           // function with 1 parameter
+    "pub": {                                        // publication channels
+        "serial": {
+            "Enable": true,
+            "Interval": 1.0,
+            "IDs": ["Bat_V", "Bat_A"]               // array of node names
+        },
+        "can": {
+            "Enable": false,
+            "Interval": 0.1,
+            "IDs": ["Bat_V"]
+        },
+        "mqtt": {
+            "Enable": true,
+            "Interval": 3600,
+            "Topic": "chargers/device-id/pub",
+            "IDs": ["Bat_V", "Bat_A"]
+        }
+    },
+    "sub": {                                        // subscription channels
+        "mqtt": {                                   // may have callback attached
+            "Topic": "chargers/device-id/sub",
+            "IDs": ["EnableCharging"]
+        }
+    }
+}
+```
+
+The data nodes are structured in the main different categories info, conf, input, output and rec. By convention, data node names use [upper camel case](https://en.wikipedia.org/wiki/Camel_case), inner nodes nodes use lower case names.
+
+The exec category is special, as it provides functions that can be called. In order to distinguish functions from a normal data nodes, executable node names are lower case.
+
+The pub node is used to configure different types of publication messages, so it doesn't hold normal data nodes.
+
+### Categories
+
+The following categories for data nodes are used for the ThingSet protocol by default:
+
+| Category | Description | Access  |
+|----------|-------------|---------|
+| info     | Device information (e.g. manufacturer, software version) | read access |
+| conf     | Configurable settings, stored in non-volatile memory after change | read/write access, expert settings may be password-protected |
+| input    | Input nodes (e.g. actuators) | write access |
+| output   | Output nodes (e.g. sensor data) | read access |
+| rec      | Recorded (history-dependent) data (e.g. min/max values) | read access, restricted write access to reset |
+| cal      | Factory-calibrated settings | read/write access, protected
+| exec     | Executable functions | partly access restricted |
+
+The nodes of input and output categories are used for instantaneous data. Changes to input nodes are only stored in RAM, so they get lost after a reset of the device. In contrast to that, conf data is stored in non-volatile memory (e.g. flash or EEPROM) after a change. As non-volatile memory has a limited amount of write cycles, configuration data should not be changed continously.
+
+The recorded data category is used for history-dependent data like error memory, energy counters or min/max values of certain measurements. In contrast to data of output category, recorded data cannot be obtained through measurement after reset, so the current state has to be stored in non-volatile memory on a regular basis.
+
+Factory calibration data nodes are only accessible for the manufacturer after authentication.
+
+Excecutable data means that they trigger a function call in the device firmware. Child nodes of the executable node can be used to define parameters that can be passed to the function.
+
+Data node IDs are stored as unsigned integers. The firmware developer should assign the lowest IDs to the most used data objects, as they consume less bytes during transfer (see CBOR representation of unsigned integers).
+
+### Units
+
+Only [SI units](https://en.wikipedia.org/wiki/International_System_of_Units) and derived units (e.g. kWh for energy instead of Ws) are allowed.
+
+The unit is appended to the data object name using an underscore. In order to keep the data object name very compact, the unit is also used to identify the physical quantity of the value. So instead of "BatteryEnergy_kWh" a short name like "Bat_kWh" is preferred.
+
+Some special characters have to be replaced according to the following table in order to be compatible with URIs (see [RFC 3986, section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3)):
+
+| Character | Replacement | Example                                      |
+|-----------|-------------|----------------------------------------------|
+| °         | deg         | "Ambient_degC" for ambient temperature in °C |
+| %         | pct         | "Humidity_pct" for relative humidity in %    |
+| /         | -           | "Veh_m-s" for vehicle speed in m/s           |
+| ^         | (omitted)   | "Surface_m2" for surface area in m^2         |
+
+## Function Codes
+
+The first byte of a ThingSet message is either a text-mode identifier ('?', '=', '!', '+', '-', ':' and '#'), a binary request code or a binary status code. Received data with unknown first byte is ignored, so that other text output (e.g. debug print information) can be used in parallel to the ThingSet protocol on the same serial interface.
+
+### Requests
+
+The protocol supports the typical [CRUD operations](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete). Request codes match with CoAP to allow transparent translation and routing between ThingSet and HTTP APIs or CoAP devices.
+
+| Code | Text ID | Method | Description                                 |
+|------|---------|--------|---------------------------------------------|
+| 0x01 | ?       | GET    | Retrieve all data from a node               |
+| 0x02 | + or !  | POST   | Append data to a node or execute a function |
+| 0x04 | -       | DELETE | Delete data from a node                     |
+| 0x05 | ?       | FETCH  | Retrieve a subset of data from a node       |
+| 0x07 | =       | iPATCH | Update (overwrite) data of a node           |
+
+The CoAP PUT and PATCH methods are not explicitly implemented. PUT is equivalent to an update of all sub-nodes of a resource using a PATCH request. PATCH requests for ThingSet are always idempotent, so only the iPATCH request code is supported. The two different text IDs for POST requests are synonyms. It is decided based on the type of the node if the request is understood as a function call or a request to create a resource.
+
+Additional request codes may be introduced in the future. Codes 0x0A, 0x0D and 0x20-0x7F are reserved, as they represent the ASCII characters for readable text including LF and CR.
+
+### Responses
+
+Response messages in binary format are identified by a first byte greater than or equal to 128 (0x80) containing a status code which shows if the request could be handled successfully. For status codes between 0x80 and 0x9F, the response was successful. If the status code is greater than or equal to 0xA0, an error occured.
+
+The status codes are again aligned with CoAP response codes, but contain an offset so that there is no interference with ASCII characters (less than 0x80).
+
+| Code | CoAP | HTTP | Description   | Comment                    |
+|------|------|------|---------------|----------------------------|
+| 0x81 | 2.01 | 201  | Created       | Answer to POST requests appending data |
+| 0x82 | 2.02 | 204  | Deleted       | Answer to DELETE request   |
+| 0x83 | 2.03 | 200  | Valid         | Answer to POST requests to exec nodes |
+| 0x84 | 2.04 | 204  | Changed       | Answer to PATCH requests   |
+| 0x85 | 2.05 | 200  | Content       | Answer to GET / FETCH requests |
+| 0xA0 | 4.00 | 400  | Bad Request   | |
+| 0xA1 | 4.01 | 401  | Unauthorized  | Authentication needed       |
+| 0xA3 | 4.03 | 403  | Forbidden     | Trying to write read-only value |
+| 0xA4 | 4.04 | 404  | Not Found     | |
+| 0xA5 | 4.05 | 405  | Method Not Allowed         | If e.g. DELETE is not allowed for that node |
+| 0xA8 | 4.08 | 400  | Request Entity Incomplete  | |
+| 0xA9 | 4.09 | 409  | Conflict                   | Configuration conflicts with other settings |
+| 0xAD | 4.13 | 413  | Request Entity Too Large   | |
+| 0xAF | 4.15 | 415  | Unsupported Content-Format | If trying to assign a string to an int |
+| 0xC0 | 5.00 | 500  | Internal Server Error      | |
+| 0xC1 | 5.01 | 501  | Not Implemented            | |
+
+The text mode converts the the hexadecimal response code into a string without the 0x prefix. The binary mode uses the code directly as the first byte.
+
+### Publication messages
+
+Publication messages are neither requests nor response messages, as they are sent without expecting a confirmation. Below table lists the message specifier in text and binary mode.
+
+| Code | Text ID | Description         |
+|------|---------|---------------------|
+| 0x1F | #       | Publication message |
+
+More details regarding the ThingSet protocol methods for data access will be explained in the next chapter.

--- a/docs/v0.3/2b_text_mode.md
+++ b/docs/v0.3/2b_text_mode.md
@@ -1,0 +1,157 @@
+# Text Mode
+
+The following description of the ThingSet text mode grammar uses ABNF according to [RFC 5234](https://tools.ietf.org/html/rfc5234).
+
+For rule names prefixed with `json-` consider the JSON specification in [RFC 8259](https://tools.ietf.org/html/rfc8259). In context of the ThingSet protocol, JSON data must be in the most compact form, i.e. not contain any unnecessary whitespaces or line breaks.
+
+### Requests
+
+Each request message consists of a first character as the request method identifier, a path specifying the endpoint of the request and a JSON string for the payload data (if applicable).
+
+    txt-request = txt-get / txt-fetch / txt-patch / txt-create / txt-delete / txt-exec
+
+    txt-get    = "?" path [ "/" ]                   ; CoAP equivalent: GET request
+
+    txt-fetch  = "?" path " " json-array            ; CoAP equivalent: FETCH request
+
+    txt-patch  = "=" path " " json-object           ; CoAP equivalent: iPATCH request
+
+    txt-create = "+" path " " json-value            ; CoAP equivalent: POST request
+
+    txt-delete = "-" path " " json-value            ; CoAP equivalent: DELETE request
+
+    txt-exec   = "!" path [ " " json-value ]        ; CoAP equivalent: POST request
+
+    path = node-name [ "/" node-name ]
+
+    node-name = ALPHA / DIGIT / "_" / "-" / "."     ; compatible to URIs (RFC 3986)
+
+The path to access a specific node is a JSON pointer ([RFC 6901](https://tools.ietf.org/html/rfc6901)) without the forward slash at the beginning. The useable characters for node names are further restricted to allow un-escaped usage in URLs.
+
+### Response
+
+The response starts with a colon ':' followed by the the status code and a plain text description of the status finished with a '.'. The description is not strictly specified and can be according to the table in the [General Concept chapter](2a_general.md) or a more verbose message. However, it must contain only one dot at the end of the description, signifying the end of the description.
+
+The bytes after the dot contain the requested data.
+
+    txt-response = ":" status [ " " json-value ]    ; response code and data
+
+    status = status-code [ " " status-msg ] "."
+
+    status-code = 2( hex )
+
+    status-msg  = *( ALPHA / SP )
+
+    hex = DIGIT / %x41-46                           ; upper-case HEXDIG
+
+### Publication message
+
+The publication message is very simple and consists of a hash sign and a whitespace at the beginning, followed by a map of data node name/value pairs.
+
+    txt-pubmsg = "# " json-map                      ; publication message
+
+## Read data
+
+The GET function allows to read all child nodes of the specified path. If a forward slash is appended at the end of the path, only an array with the child node names is returned. Otherwise all content below that path (names and values) is returned.
+
+The FETCH function allows to retrieve only subset of the child nodes, defined by an array with the node names passed to the function.
+
+Only those data nodes are returned which are at least readable. Thus, the result might differ after authentication.
+
+**Example 1:** Discover all child nodes of the root node (i.e. categories)
+
+    ?/
+    :85 Content. ["info","conf","input","output","rec","exec","pub"]
+
+**Example 2:** Retrieve all content of output path (keys + values)
+
+    ?output
+    :85 Content. {"Bat_V":14.2,"Bat_A":5.13,"Ambient_degC":22}
+
+**Example 3:** List all sub-nodes of output path as an array
+
+    ?output/
+    :85 Content. ["Bat_V","Bat_A","Ambient_degC"]
+
+**Example 4:** Retrieve single data node "Bat_V"
+
+    ?output ["Bat_V"]
+    :85 Content. [14.2]
+
+## Update data
+
+Requests to overwrite the value of a data node.
+
+Data of category conf will be written into persistent memory, so it is not allowed to change settings periodically. Only data of category input can be changed regularly.
+
+**Example 1:** Disable charging
+
+    =input {"EnableCharging":false}
+    :84 Changed.
+
+**Example 2:** Attempt to write read-only measurement values (output category)
+
+    =output {"Bat_V":15.2,"Ambient_degC":22}
+    :A3 Forbiden.
+
+## Create data
+
+Appends new data to a data node.
+
+**Example 1:** Add "Bat_V" to the serial publication channel
+
+    +pub/serial/ids "Bat_V"
+    :81 Created.
+
+## Delete data
+
+Removes data from a node of array type.
+
+**Example 1:** Remove "Bat_V" from "serial" publication channel
+
+    -pub/serial/ids "Bat_V"
+    :82 Deleted.
+
+## Execute function
+
+Executes a function identified by a data object name of category "exec"
+
+**Example 1:** Reset the device
+
+    !exec/reset
+    :83 Valid.
+
+## Authentication
+
+Some of the device parameters like calibration or config settings should be protected against unauthorized change. A simple authentication method is suggested where multiple user levels can be implemented in the firmware using different passwords. The manufacturer would use a different one to authenticate than a normal user and thus get more rights to access data objects.
+
+The password is transferred as a plain text string. Encryption has to be provided by lower layers.
+
+Internally, the authentication function is implemented as a data node of exec type.
+
+    !auth "mypass"
+    :83 Valid.
+
+After successful authentication, the device exposes restricted data nodes via the normal data access requests. The authentication stays valid until another auth command is received, either without password or with a password that doesn't match.
+
+## Publication messages
+
+The pub node is used to configure the device to publish certain data on a regular basis through a defined communication channel (UART, CAN, LoRa, etc.). If implemented in the firmware, the publication interval may be adjustable.
+
+**Example 1:** List all available publication channels
+
+    ?pub/
+    :85 Content. ["serial","can"]
+
+**Example 2:** Enable "serial" publication channel
+
+    =pub/serial {"Enable":true}
+    :84 Changed.
+
+With this setting, the following message is automatically sent by the device once per second:
+
+    # {"Bat_V":14.1,"Bat_A":5.13}
+
+Publication messages are broadcast to all connected devices. No response is sent from devices receiving the message.
+
+The data nodes to be published via one channel (e.g. serial) can be configured using POST and DELETE requests to the pub/serial/IDs endpoint, as shown in the examples above.

--- a/docs/v0.3/2c_binary_mode.md
+++ b/docs/v0.3/2c_binary_mode.md
@@ -1,0 +1,304 @@
+# Binary Mode
+
+In the binary mode, the data is encoded using the CBOR format. The data structure is the same as in text mode, but numeric node IDs are used as identifiers by default instead of the node names.
+
+The length of the entire request or response is not encoded in the ThingSet protocol, but can be determined from the CBOR format. Packet length as well as checksums should be encoded in lower layer protocols. It is assumed that the parser always receives a complete request.
+
+### Requests
+
+Each request message consists of a first byte as the request method identifier, a path or ID specifying the endpoint of the request and CBOR data as payload (if applicable).
+
+    bin-request = bin-get / bin-post / bin-delete / bin-fetch / bin-ipatch / bin-nameid
+
+    bin-get    = %x01 endpoint get-type
+
+    bin-post   = %x02 endpoint cbor-data      ; exec or create is determined
+                                              ; based on node type
+
+    bin-delete = %x04 endpoint cbor-uint      ; only for valid node IDs
+
+    bin-fetch  = %x05 endpoint cbor-array     ; returns only values, no keys
+
+    bin-ipatch = %x07 endpoint cbor-map
+
+    bin-nameid = %x1E endpoint cbor-array     ; get names of ids or vice versa
+
+    endpoint   = path         ; CBOR string: path same as text mode
+               / parent-id    ; CBOR uint: parent node ID instead of path
+               / %xF7         ; CBOR undefined: wildcard matching any path / parent
+
+    get-type   = %xF7         ; CBOR undefined: returns array of node IDs (default)
+               / %x80         ; CBOR emtpy array: returns array of names
+               / %xA0         ; CBOR empty map: returns name:value map
+
+### Response
+
+Responses in binary mode start with the error/status code as specified before, followed by the data if applicable.
+
+    bin-response = %x80-FF [ cbor-data ]      ; response code and data
+
+### Publication message
+
+Binary publication messages follow the same concept as in text mode.
+
+    bin-pubmsg = %x1F cbor-map                ; map containing node IDs and values
+
+## Name and ID mapping
+
+The examples in this chapter are based on the same data structure as introduced in the [General Concept chapter](2a_general.md#data-structure), but each node is identified by an ID. The assignment of IDs and names is shown in the following JSON-like structure (actual JSON supports neither numbers as keys nor comments):
+
+```JSON
+{
+    "18": {                             // info
+        "19": "MPPT 1210 HUS",          // DeviceType
+    },
+    "30": {                             // conf
+        "31": 14.4,                     // BatCharging_V
+    },
+    "60": {                             // input
+        "61": true                      // EnableCharging
+    },
+    "70": {                             // output
+        "71": 14.1,                     // Bat_V
+        "72": 5.13,                     // Bat_A
+        "73": 22                        // Ambient_degC
+    },
+    "A0": {                             // rec
+        "A1": 1984,                     // BatChgDay_Wh
+    },
+    "D0": {                             // cal
+    },
+    "E0": {                             // exec
+        "E1": null,                     // reset
+    },
+    "EF": ["Password"],                 // auth
+    "F0": {                             // pub
+        "F1": {                         // serial
+            "F2": true,                 // Enable
+            "F3": 1.0,                  // Interval
+            "F4": ["71", "72"]          // IDs
+        },
+        "F5": {                         // can
+            "F6": false,                // Enable
+            "F7": 0.1,                  // Interval
+            "F8": ["71"]                // IDs
+        }
+    }
+}
+```
+
+The firmware developer is free to choose the IDs. However, above IDs for the nodes of the first layer are used by Libre Solar devices and recommended for the following reasons:
+
+- IDs from 0x00 to 0x17 are left for data nodes that are sent very often, as they consume only a single byte in CBOR encoding
+- The node IDs specifying the categories are spaced such that there should be enough free node IDs for most devices
+- As the node IDs are strictly increasing, the data layot is compatible with the draft standard [CBOR Encoding of Data Modeled with YANG](https://tools.ietf.org/html/draft-ietf-core-yang-cbor).
+
+In contrast to the text mode, the binary mode has a special NAMEID request (without CoAP equivalent) that allows to get a name for an ID or vice versa.
+
+**Example 1:** Request name of node IDs 0x71 and 0x72
+
+    Request:
+    1E                                      NAMEID request
+       18 70                                # CBOR uint: 0x70 (parent ID)
+       82                                   # CBOR array (2 elements)
+          18 71                             # CBOR uint: 0x71 (node ID)
+          18 72                             # CBOR uint: 0x72 (node ID)
+
+    Response:
+    85                                      Content.
+       82                                   # CBOR array (2 elements)
+          65 4261745F56                     # CBOR string: "Bat_V"
+          65 4261745F41                     # CBOR string: "Bat_A"
+
+If the parent ID is passed as the endpoint, only the data node name is returned. All requested nodes must be children of the same parend node in this case.
+
+**Example 2:** Request full path of node ID 0x71 (Bat_V)
+
+    Request:
+    1E                                      NAMEID request
+       F7                                   # CBOR undefined as a wildcard
+       18 71                                # CBOR uint: 0x71 (node ID)
+
+    Response:
+    85                                      Content.
+       6C 6F75747075742F4261745F56          # CBOR string: "output/Bat_V"
+
+If the path of a node is unknown (e.g. because it was obtained from a publication message), the entire path (see text mode) can be determined by setting the endpoint to undefined, as shown above.
+
+**Example 3:** Request IDs for known data node names
+
+    Request:
+    1E                                      NAMEID request
+       F7                                   # CBOR undefined as a wildcard
+       82                                   # CBOR array (2 elements)
+          65 4261745F56                     # CBOR string: "Bat_V"
+          65 4261745F41                     # CBOR string: "Bat_A"
+
+    Response:
+    85                                      Content.
+       82                                   # CBOR array (2 elements)
+          18 71                             # CBOR uint: 0x71 (node ID)
+          18 72                             # CBOR uint: 0x72 (node ID)
+
+Also here a wildcard for the endpoint can be used to query the entire database. However, if multiple nodes with the same name are found, an error must be returned. This should not be the case for a properly designed data structure.
+
+## Read data
+
+Similar to the text mode, the binary variants of the GET and FETCH functions also allow to read one or more data objects. The objects are identified by their parent node (endpoint of a path) and their ID or their name.
+
+The GET function is useful for device discovery, as it can list all childs of a node. Depending on the computing power of the device and the host, the GET request can either return only the IDs of the next layer or maps including the values. In order to be compatible to the text mode, it is also possible to retrieve all child nodes of a resource as a map of name/value pairs.
+
+The binary mode also allows to work only with IDs and no paths or node names to keep message size at a minimum. In order to discover the nodes of a device, the host can first query all child IDs of a node (starting with root node of ID 0), afterwards query the names for each ID once and then request the value for any data object on demand.
+
+**Example 1:** Discover all child nodes of the root node (i.e. categories)
+
+    Request:
+    01                                      GET request
+       00                                   # CBOR uint: 0x00 (root node)
+       F7                                   # CBOR undefined as a wildcard
+
+    Response:
+    85                                      Content.
+       89                                   # CBOR array (9 elements)
+          18 18                             # CBOR uint: 0x18
+          18 30                             # CBOR uint: 0x30
+           ...
+          18 F0                             # CBOR data: 0xF0
+
+**Example 2:** Retrieve all data of output path (keys + values)
+
+    Request (alternative 1):
+    01                                      GET request
+       18 70                                # CBOR uint: 0x70
+       A0                                   # CBOR empty map
+
+    Request (alternative 2):
+    01                                      GET request
+       66 6F7574707574                      # CBOR string: "output"
+       A0                                   # CBOR empty map
+
+    Response:
+    85                                      Content.
+       A3                                   # CBOR map (3 elements)
+          65 4261745F56                     # CBOR string: "Bat_V"
+          FA 4161999A                       # CBOR float: 14.1
+          65 4261745F41                     # CBOR string: "Bat_A"
+          FA 40A428F6                       # CBOR float: 5.13
+          6C 416D6269656E745F64656743       # CBOR string: "Ambient_degC"
+          16                                # CBOR uint: 22
+
+Note that the empty map requests to respond with name/value pairs as specified in the request grammar at the beginning of the chapter.
+
+**Example 3:** Retrieve value of data node "Bat_V"
+
+    Request (alternative 1):
+    05                                      FETCH request
+       66 6F7574707574                      # CBOR string: "output" (path)
+       65 4261745F56                        # CBOR string: "Bat_V" (node name)
+
+    Request (alternative 2):
+    05                                      FETCH request
+       18 70                                # CBOR uint: 0x70 (parent ID)
+       18 71                                # CBOR uint: 0x71 (node ID)
+
+    Response:
+    85                                      Content.
+       FA 4161999A                          # CBOR float: 14.1
+
+**Example 4:** Retrieve multiple data nodes:
+
+    Request:
+    05                                      FETCH request
+       18 70                                # CBOR uint: 0x70 (parent ID)
+       82                                   # CBOR array (2 elements)
+          18 71                             # CBOR uint: 0x71 (node ID)
+          18 72                             # CBOR uint: 0x72 (node ID)
+
+    Response:
+    85                                      Content.
+       82                                   # CBOR array (2 elements)
+          FA 4161999A                       # CBOR float: 14.1
+          16                                # CBOR uint: 22
+
+The binary mode also allows to use data object names (strings) instead of numeric IDs, which increases the amount of transferred data.
+
+## Update data
+
+Requests to overwrite the value a data node.
+
+The device must support a patch request using the same CBOR data type as used in the response of a GET or FETCH request for the given objects. Optionally, the device may also accept different data types (e.g. float32 instead of int) and convert the data internally.
+
+If the data type is not supported, an error status code (36) is responded.
+
+**Example 1:** Disable charging
+
+    Request:
+    07                                      PATCH request
+       18 70                                # CBOR uint: 0x70
+       A1                                   # CBOR map (1 element)
+          18 61                             # CBOR uint: 0x61
+          F4                                # CBOR data: false
+
+    Response:
+    84                                      Changed.
+
+**Example 2:** Attempt to write read-only measurement values (output category)
+
+    Request:
+    07                                      PATCH request
+       A2                                   # CBOR map (2 elements)
+          18 71                             # CBOR uint: 0x71
+          FA 0x41633333                     # CBOR float32: 14.2
+          18 73                             # CBOR uint: 0x73
+          16                                # CBOR uint: 22
+
+    Response:
+    A3                                      Forbidden.
+
+## Create data
+
+Appends new data to a data node in a similar way as in the text mode.
+
+**Example 1:** Add node ID 0x72 (Bat_A) to the serial publication channel
+
+    Request:
+    02                                      POST request
+       18 F4                                # CBOR uint: 0xF4 (parent ID)
+       18 72                                # CBOR uint: 0x72 (node ID)
+
+    Response:
+    81                                      Created.
+
+## Delete data
+
+Removes data from a node of array type.
+
+**Example 1:** Remove node ID 0x72 (Bat_A) from serial publication channel
+
+    Request:
+    04                                      DELETE request
+       18 F4                                # CBOR uint: 0xF4 (parent ID)
+       18 72                                # CBOR uint: 0x72 (node ID)
+
+    Response:
+    82                                      Deleted.
+
+## Execute function
+
+For execution of a function, the same POST request is used as when creating data. The device decides based on the type of the endpoint whether the request is a function call or a request to create data.
+
+**Example 1:** Reset the device
+
+    Request:
+    02                                      POST request
+       18 E1                                # CBOR uint: 0xE1 (node ID)
+       80                                   # CBOR empty array
+
+    Response:
+    83                                      Valid.
+
+Note that the endpoint is the node of the executable function itself. Data can be passed to the called function as the second parameter, but the "reset" function does not require any parameters, so it receives an empty array.
+
+## Other functions
+
+Authentication, publication request setup and publication messages work analog to text mode.

--- a/docs/v0.3/3a_serial.md
+++ b/docs/v0.3/3a_serial.md
@@ -1,0 +1,43 @@
+---
+title: "Serial"
+---
+
+# Serial
+
+The serial interface can be a hardware UART interface directly with a microcontroller a virtual serial via USB or Bluetooth.
+
+## UART
+
+As serial communication to a microcontroller via UART does not provide any error checking, a CRC checksum is appended to each message in the text mode.
+
+The following extensions for the grammar as described in [Text Mode chapter](2b_text_mode.md) are used:
+
+    thingset-msg  = ( request / response / pub-msg )
+
+    thingset-uart = thingset-msg end
+
+    end = [ " " checksum ] [ CR ] LF
+
+    checksum = 8( hex )                         ; CRC-32, hex always upper case
+
+The CRC checksum is calculated over the entire thingset-msg as defined above. The same CRC-32 polynom 0x04C11DB7 as for [Ethernet and many other protocols](https://en.wikipedia.org/wiki/Cyclic_redundancy_check) is used.
+
+The CRC is optional so that it is still possible to interact with the device by humans using a terminal. However, the device should always calculate the CRC and in case of M2M communication, the client should check the CRC and also provide a CRC for requests to increase reliability.
+
+::: warning
+The binary protocol mode is curently not supported, as it would require some way to determine the end of a message.
+:::
+
+## USB
+
+USB supports a virtual COM port via the CDC ACM device class.
+
+If the USB interface is directly provided by the microcontroller, the checksum as for the UART interface is not needed, USB already provides error-checking in that case.
+
+If a USB-to-UART converter (e.g. FTDI) is used to interact with the device, this is not considered a "virtual serial interface", as there is still a physical UART interface used between the converter and the device. Thus, checksums should be used.
+
+## Bluetooth
+
+For Bluetooth, the Serial Port Profile (SPP) is used to simulate a serial interface.
+
+For CRC checksums the same rules apply as for USB.

--- a/docs/v0.3/3b_can.md
+++ b/docs/v0.3/3b_can.md
@@ -1,0 +1,214 @@
+---
+title: "CAN"
+---
+
+# CAN Transport and Network Layer
+
+::: warning
+The CAN bus part of the ThingSet protocol is still in an early stage and may change in the future.
+:::
+
+This specification defines layer 3 (Network) and 4 (Transport) of the ThingSet Protocol via CAN bus. Layer 1 and 2 are provided by the CAN bus itself.
+
+Only the binary messages of the ThingSet Protocol are supported via CAN.
+
+## General features
+
+- Master-less operation
+- Automatic node ID assignment
+- Efficient useage of CAN ID and data bytes
+- Transport protocol to allow payload of more than 8 bytes
+- Two different types of messages for application layer
+    - Service message (request/response)
+    - Publication message (publish/subscribe)
+- RTR frame is not allowed
+- Fixed bitrate of 250 kbit
+
+### CAN identifier layout
+
+In the CAN bus, the identifier part of the CAN frame is used for arbitration and identification of the message type. Typically, it does not define the sender or receiver of the message, but the content of the message.
+
+For a network with connected ThingSet devices, the layout of the CAN identifier is similar to the SAE J1939 specification. Parts of the identifier define the source and destination address of the message. In addition to that, the first three bits are used to prioritize the messages.
+
+Two general types of messages are specified: Service message and publication message. Only CAN extended IDs with a size of 29 bit are used.
+
+## Service message
+
+A service message is used for the request/response messaging pattern. A single byte each for source and destination node address are defined as part of the CAN ID to identify sender and receiver of the message.
+
+### CAN identifier layout
+
+The service message addressing in 29-bit CAN ID is similar to SAE J1939:
+
+| Bits | 28 .. 26 | 25 | 24 |    23 .. 16     |   15 .. 8      |   7 .. 0       |
+|------|:--------:|:--:|:--:|:---------------:|:--------------:|:--------------:|
+|      | Priority | 1  | 0  | reserved (0xDA) | Target address | Source address |
+
+- Priority (28-26): Defines the importance of the message. For service messages, only 3 (high priority) or 7 (low priority) are valid.
+- Extended data page / EDP (25): Always 1b to prevent collision with SAE J1939 and NMEA2000 devices on the same bus
+- Message type (24): 0b for service message
+- Reserved (23-16): Set to 218 (0xDA) as suggested by ISO-TP standard (ISO 15765-2) for normal fixed addressing with N_TAtype = physical
+- Target address (15-8): Destination node address
+- Source address (7-0): Source node address (255 for anonymous message during address claiming)
+
+### Transport protocol (ISO 15765-2)
+
+In order to transfer data with a length of more than 8 bytes, the transfer protocol specified in [ISO 15765-2 (ISO-TP)](https://en.wikipedia.org/wiki/ISO_15765-2) is used.
+
+It allows a maximum number of 4095 data bytes (defined by 12 bit unsigned int length code in first frame). Flow control mechanisms ensure the reliability of data reception.
+
+As a very important feature, ISO-TP allows the efficient transfer of single-frame messages with only one byte of overhead (and no flow control packets). This feature is necessary, as it is not known in advance if a certain function of the ThingSet protocol will transfer only a few bytes or a large amount of data.
+
+The ISO-TP standard is not accessible for free. However, several open source implementations (including [SocketCAN for Linux](https://github.com/hartkopp/can-isotp)) of the ISO-TP are available. Most important information about the frame layout can be found on [Wikipedia](https://en.wikipedia.org/wiki/ISO_15765-2).
+
+#### Single-frame message request/response
+
+Application protocol data of 7 bytes or lower can be transferred using a single CAN frame. The first byte of the CAN data contains the ISO-TP header for a single-frame message. Bytes 2 to n (with n <= 7) are contained in the remaining data bytes of the CAN frame.
+
+<table><thead><tr>
+    <th>Byte 1</th><th>Byte 2</th><th>...</th><th>Byte 8</th>
+</tr></thead><tbody><tr>
+	<td>ISO-TP header</td>
+    <td>Application protocol (byte 1)</td>
+	<td>...</td>
+    <td>Application protocol (byte 7)</td>
+</tr></tbody></table>
+
+#### Multi-frame message request/response
+
+More than 7 bytes of application protocol data are sent as multi-frame messages.
+
+The first message contains two bytes for the ISO-TP header (including the total message length).
+
+<table><thead><tr>
+    <th>Byte 1</th><th>Byte 2</th><th>Byte 3</th><th>...</th><th>Byte 8</th>
+</tr></thead><tbody><tr>
+	<td colspan="2">ISO-TP header</td>
+    <td>Application protocol (byte 1)</td>
+	<td>...</td>
+    <td>Application protocol (byte 6)</td>
+</tr></tbody></table>
+
+Consecutive messages i = 2...585 consume only one byte for the ISO-TP header:
+
+<table><thead><tr>
+    <th>Byte 1</th><th>Byte 2</th><th>...</th><th>Byte 8</th>
+</tr></thead><tbody><tr>
+	<td>ISO-TP header</td>
+    <td>Application protocol (byte (i-1)*7)</td>
+	<td>...</td>
+    <td>Application protocol (byte i*7-1)</td>
+</tr></tbody></table>
+
+
+### Remarks regarding existing transport protocols
+
+Several other transport protocols for CAN have been defined in different standards.
+
+For the J1939 protocol, the transport protocol is specified in the standard **SAE J1939-21**. Two types of transport protocol are defined: The Connection Mode Data Transfer (CMDT) and the Broadcast Announce Message (BAM). CMDT is used to exchange data between two nodes. It includes methods for flow control and handshake. BAM is more simple and broadcasts a multi-packet message to the bus without feedback if the message was received.
+
+CMDT and BAM allow to transfer 9 to 1785 bytes (255 packets * 7 bytes) of payload. It is not allowed to transfer 0 to 8 bytes using the J1939 transport protocols. Thus, we need to know before if a message needs the mechanisms of the transport protocol or not. This is not possible for the flexible ThingSet protocol, as the same functions might transfer either very little data (e.g. write 16-bit integer) or a large amount of data (e.g. write multiple values or strings). Data with less than 9 bytes would have to be stuffed, making the protocol very inefficient. A message which could fit into a single CAN frame would need 5 frames (including flow control) when using CMDT and stuffing.
+
+The **RV-C** standard defines a different transport protocol than SAE J1939, which also allows the transfer of up to 1785 bytes. However, is does not specify any flow control mechanisms at all. So it is not possible to determine if a message was received even for a communication between only two nodes, which is not acceptable.
+
+NMEA 2000 uses the same transport protocol as the SAE J1939 protocol. In addition to that, it defines a so-called fast packet protocol. With **NMEA 2000 fast packet protocol**, 223 bytes can be transferred without flow control, thus, making it more efficient and "fast".
+
+With the fast packet protocol, a single frame transfer is possible. However, a single frame message consumes 2 out of 8 bytes for the fast packet header information. This is considered too high overhead if it is unknown whether a single or multi-frame message has to be used.
+
+Overview of different CAN based transport protocols:
+
+|                        | ISO-TP  | NMEA 2000<br/>fast packet | SAE J1939-21 | RV-C    |
+|------------------------|:-------:|:-------------------------:|:------------:|:-------:|
+| Number of data bytes   | 0..4095 | 0..223                    | 9..1785      | 9..1785 |
+| Flow control           | yes     | no                        | yes          | no      |
+| Efficient single frame | yes     | no                        | no           | no      |
+| Open standard          | no      | no                        | no           | yes     |
+
+
+<!---
+#### NMEA2000 Fast Packet
+
+- 3 bit sequence identifier (same for each sequence, incremented for new session)
+- 5 bit frame counter
+- 1 byte overall length in first frame
+- Maximum data bytes: (5^2 - 1) * 7 + 6 bytes = 223
+- Trailing bytes of last frame filled with 0xFF
+
+http://www.auelectronics.com/forum/index.php?PHPSESSID=ns0k786e6jvacog3re04jh6e50&topic=421.msg1185#msg1185
+
+First frame:
+- Byte 1:
+    - b0 – b4 = 00000, b0 =LSB
+    - b5 – b7 = 3-bit sequence counter to distinguish separate fast-packet messages of the same PGN, b5 is the LSB of the counter.
+- Byte 2: Total  number of data bytes to be transmitted in the message (0 to 223).
+- After Byte 2, the frame also includes up to (6) data bytes in the first frame (and up to (7) data bytes in following frames).
+
+Subsequent frames:
+- Byte 1:
+    - b0 – b4 = 1 to 31, 5 bit frame counter,  b0  =LSB
+    - b5  –  b7  = 3 -bit sequence counter which shall be the same value as in the first frame, b5 is the LSB of the counter.
+- Byte 2-8: 7 bytes of transmitted data. Unused bits in the last frame of a fast-packet message shall be filled with "1" bits.
+-->
+
+## Publication message
+
+The publication message provides a very efficient way to send data in a regular interval using a single CAN frame without the overhead of a transport protocol. The publication messages are mainly intended for monitoring purposes.
+
+### CAN identifier layout
+
+Publication messages are not sent to a single node, so the destination address does not need to be specified. Instead, the data node ID is specified directly in the CAN identifier to have more bytes available for payload in the data section of the CAN frame.
+
+| Bits | 28 .. 26 | 25 | 24 |   23 .. 16         |   15 .. 8          |   7 .. 0       |
+|------|:--------:|:--:|:--:|:------------------:|:------------------:|:--------------:|
+|      | Priority | 1  | 1  | Data node ID (MSB) | Data node ID (LSB) | Source address |
+
+- Priority (28-26): Defines the importance of the message. For publication messages, only 4 (high priority), 5 (medium priority) and 6 (low priority) are valid.
+- Extended data page / EDP (25): Always 1b to prevent collision with SAE J1939 and NMEA2000 devices on the same bus
+- Message type (24): 1b for publication message
+- Data node ID (23-8): Data node ID as a 16-bit unsigned integer. The most significant byte is stored first (bits 23 to 16).
+- Source address (7-0): Source node address (255 for anonymous message during address claiming)
+
+The data node ID is not encoded in the CBOR format, but as a raw 16-bit unsigned integer. The publication messages are limited to IDs that fit into 16 bits.
+
+### CAN data format
+
+The data section of the CAN frame contains the CBOR-encoded value of the data node with the specified ID.
+
+In order to acquire real-time measurement values, a 16-bit timestamp (unsigned int) can be appended to the CBOR-encoded value. The timestamp contains the 16 least significant bits of the microcontroller's system clock in milliseconds. It is a rolling counter and restarts at 0 after an overflow. The timestamp cannot be used to determine the absolute time of a measurement, but the time difference between subsequent measurements. This is important to obtain correct sampling of time-series data if higher priority messages cause a delay of the data delivery on the bus.
+
+The maximum length of the value and the optional timestamp is defined by the maximum data section size of the CAN frame (8 bytes for classic CAN).
+
+## Physical layer
+
+### Bit rate
+
+ThingSet uses a fixed bit rate of 500 kbit/s, which supports a maximum bus length of 100 m according to CiA 301.
+
+### Connector
+
+Standard RJ45 jacks as used for Ethernet are also used as the default for ThingSet via CAN. The cables should be Cat 5e twisted pair or better, allowing reliable communication with easily available parts.
+
+The pinout of the connector is similar to the CANopen specification:
+
+| Pin # | Name  | Description |
+|-------|-------|-------------|
+| 1     | CAN_H | CAN bus high signal |
+| 2     | CAN_L | CAN bus low signal |
+| 3     | GND   | CAN and power supply GND (optional) |
+| 4     | V+    | Bus power supply (optional, 12-24V nominal) |
+| 5     | V+    | Bus power supply (optional, 12-24V nominal) |
+| 6     | -     | reserved (do not connect) |
+| 7     | GND   | CAN and power supply GND (optional) |
+| 8     | (V+)  | Unconnected by default, optional jumper to V+ |
+
+The pinout specification aims to create as little interference with existing standards as possible. Most important, any damage must be prevented if a device is accidentally connected to a standard Ethernet jack.
+
+In contrast to the CANopen specification, pin 8 is not used as the bus power supply (V+) by default. 10/100 MBit Ethernet jacks with integrated magnetics (e.g. [these ones](https://katalog.we-online.de/pbs/download/Tutorials_Connecting+LAN+Transformers_EN+%28rev1%29.pdf)) internally connect pin 4 to 5 and pin 7 to 8. In addition to that, Power over Ethernet (PoE) uses pins 4+5 for positive power rail and pins 7+8 for GND. So it's not ideal to use pin 7 as GND and pin 8 as V+. Boards can however offer a jumper to connect pin 8 with the other V+ pins (4 and 5) for bus supply of CANopen devices.
+
+Galvanic isolation is not required, as long as all devices are connected via thick wires. This might change in the future.
+
+One device typically has 2 RJ45 jacks for daisy-chaining the devices and maintaining the bus topology. There is no such thing like a switch needed. However, the endpoints have to be terminated with termination plugs or resistors.
+
+A device that supplies power to V+ may not hard-connect the daisy-chained wires without any fuses in order to ensure that the current rating per wire is not exceeded. Devices without power supply may just route through the powered wires.
+
+The maximum current per wire pair is 600 mA (300 mA per wire), same as PoE+ (IEEE 802.3at Type 2) with Cat 5e cables.

--- a/docs/v0.3/3c_lorawan.md
+++ b/docs/v0.3/3c_lorawan.md
@@ -1,0 +1,9 @@
+---
+title: "LoRaWAN"
+---
+
+# ThingSet via LoRaWAN
+
+As the data rate of LoRa is very low, only the binary protocol version is supported.
+
+Detailed specification still to be done. Layout might be similar to CAN bus (but CAN has even smaller packet sizes...).

--- a/docs/v0.3/4a_http.md
+++ b/docs/v0.3/4a_http.md
@@ -1,0 +1,24 @@
+---
+title: "HTTP"
+---
+
+# ThingSet to HTTP mapping
+
+::: warning
+This part of the protocol specification is still work in progress.
+:::
+
+## Key concepts
+
+ThingSet is developed for point-to-point connections or small local networks, but the protocol functions were developed such that they can be easily integrated into larger networks or the internet using an HTTP gateway.
+
+Many web applications interact using JSON APIs (sometimes in a RESTful way), so the compatibility with JSON web APIs is an important feature of the ThingSet protocol.
+
+In order to reduce the complexity of the protocol, the features offered by HTTP were reduced:
+
+- Convention over configuration
+    - Only two content-types JSON and CBOR are supported. They are detected automatically and no content-type header is needed.
+    - Predefined URI layout matching the data structure.
+    - Unit of data objects stored in the name (key) of a map, so the required amount of nesting in the JSON data structure is limited to categories only.
+
+The response codes of ThingSet are aligned with CoAP and thus also allow a simple translation to HTTP. The main difference is that HTTP doesn't allow to indicate successful requests as fine-grained as CoAP, so the status will be mostly 200 OK or 204 No Content.

--- a/docs/v0.3/4b_coap.md
+++ b/docs/v0.3/4b_coap.md
@@ -1,0 +1,24 @@
+---
+title: "CoAP"
+---
+
+# ThingSet to CoAP mapping
+
+::: warning
+This part of the protocol specification is still work in progress.
+:::
+
+## Key concepts
+
+ThingSet uses only a subset of CoAPs features in order to make it more simple and compact:
+
+- Mapping to CoAP message types:
+    - ThingSet requests are always CON
+    - Only publication messages are NON
+    - No dedicated ACK, the response must also contain data (only piggybacked responses)
+    - RST needed? probably not...
+- No message IDs: Synchronous communication necessary
+- PUT request is not supported. Use POST to create a resource and iPATCH to update it.
+- PATCH requests are always idempotent, i.e. only iPATCH is supported
+
+The binary function codes of ThingSet are the same as CoAP method codes. The status codes are also aligned, but contain an offset as explained before.

--- a/docs/v0.3/4c_mqtt.md
+++ b/docs/v0.3/4c_mqtt.md
@@ -1,0 +1,25 @@
+---
+title: "MQTT"
+---
+
+# ThingSet to MQTT mapping
+
+The MQTT protocol doesn't support the request/response part of the ThingSet protocol, but the publish/subscribe messaging pattern can be easily mapped.
+
+## Publication
+
+The topic used to publish to the MQTT server may contain the path of the data nodes. The topic name itself could be stored as a data node, but it's not relevant to the implementation of publication messages in the ThingSet protocool.
+
+A ThingSet publication message starts with a first byte 0x1F in binary mode or "# " in text mode to indicate a publication message. Whether this byte is also stored in the MQTT topic depends on the application.
+
+If a single measurement value is stored in an MQTT topic (e.g. /devices/device-id/Bat_V for the battery voltage), it is recommended that only the JSON or CBOR payload data is stored in the MQTT payload and the path of the ThingSet endpoint is contained in the topic.
+
+If multiple data nodes are stored in the same topic, the entire ThingSet publication message could be stored to allow direct passing between MQTT topic and ThingSet.
+
+## Subscription
+
+Content fetched from a specific topic is forwarded to the ThingSet protocol as a publication message. The ThingSet device will parse the incoming data similar to a PATCH request. Unknown data nodes contained in the subscribed payload are silently ignored.
+
+If the application requires some processing of incoming data before applying them to actual nodes, temporary data nodes can be created where the subscribed content is written to. Afterwards a function is called (assigned as a callback to the sub channel node) to process the incoming data and pass it on to the actual nodes.
+
+This approach can also be used to determine if the received data has changed compared to already existing state and avoid too many storage operations in EEPROM for regularly published messages.

--- a/docs/v0.3/5a_serial.md
+++ b/docs/v0.3/5a_serial.md
@@ -1,0 +1,9 @@
+# Serial
+
+## Hardware
+
+Any USB to UART converter can be used, e.g. the one included in STM32 Nucleo boards.
+
+## Software
+
+[CuteCom](http://cutecom.sourceforge.net/) for Linux and Mac OS has a built-in command history, which makes it easy to interact manually with devices via ThingSet.

--- a/docs/v0.3/5b_can.md
+++ b/docs/v0.3/5b_can.md
@@ -1,0 +1,60 @@
+# CAN bus
+
+## Linux
+
+### CAN interface setup
+
+There are different USB to CAN dongles available on the market, which usually support communicating with the Linux Kernel via a serial interface.
+
+The following command creates a `can0` interface from a dongle attached to `/dev/ttyUSB0`:
+
+```
+sudo slcan_attach /dev/ttyUSB0 -w
+```
+
+Afterwards, the interface has to be configured and started. Here we are setting the bit rate to 500 kbit/s:
+
+```
+sudo ip link set can0 type can bitrate 500000 restart-ms 500
+sudo ip link set can0 up
+```
+
+If you want to see also your own messages, loopback mode has to be enabled before setting the interface up:
+
+```
+sudo ip link set can0 type can loopback on
+```
+
+Now, `candump` can be used to read all data available on the bus:
+
+```
+candump can0
+```
+
+### ISO-TP tools
+
+The Linux kernel [supports CAN ISO-TP](https://github.com/hartkopp/can-isotp), which is used as the transport protocol for ThingSet.
+
+Assuming a device with CAN address 10 is connected to the bus, the following command sets up an ISO-TP channel for messages from the device to the host computer (CAN address 0):
+
+```
+isotprecv -l -s 0x1ada0a00 -d 0x1ada000a can0
+```
+
+In order to send a binary command to device with address 10, run the following command:
+
+```
+echo "01 18 70 A0" | isotpsend -s 0x1ada0a00 -d 0x1ada000a can0
+```
+
+The same for text mode:
+
+```
+echo -n "?output" | hexdump -v -e '/1 "%02X "' | isotpsend -s 0x1ada0a00 -d 0x1ada000a can0
+```
+
+`isotprecv` only prints the hex values of the received data. The ASCII payload can be monitored using:
+
+```
+isotpsniffer -tA -f 2 -d 0x1ada0a00 -s 0x1ada000a can0
+```

--- a/docs/v0.3/README.md
+++ b/docs/v0.3/README.md
@@ -1,0 +1,29 @@
+# Introduction
+
+This specification describes a communication protocol for control, configuration and monitoring of connected devices. It is published under the [CC BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).
+
+The protocol is called ThingSet - a protocol for **set**tings of **thing**s. The main goals of the protocol are:
+
+### Flexible
+
+As an application layer protocol it should be widely independent of the underlying transport protocols and physical interfaces. It can be used with e.g. CAN, USB, WiFi, Bluetooth, a simple serial interface or upcoming interfaces of the future.
+
+### Compatible
+
+Easy to integrate with more protocols like CoAP or HTTP and based on common data formats like JSON.
+
+### Easy to use and human-readable
+
+Similar to Modbus, the protocol should have a text-based mode which is human-readable. This allows easy manual device communication via the serial interface. For M2M communication, a more compact binary mode should be available.
+
+### Compact footprint
+
+Implementation and binary data representations should be very compact to enable transport via LoRa and CAN. Standard CAN frames allow a payload of only 8 bytes per frame, LoRaWAN allows [51 bytes](https://www.thethingsnetwork.org/forum/t/limitations-data-rate-packet-size-30-seconds-uplink-and-10-messages-downlink-per-day-fair-access-policy/1300) of application payload per message.
+
+### Schema-less and self-explaining
+
+It should be possible to configure and monitor a device without a manual or a configuration file. This means that the protocol needs functions to discover the features and configurable settings of an unknown device. In contrast to other protocols like Modbus, you should not need to know the variable type and register address where a setting is stored.
+
+### Stateless
+
+The small devices should not need to handle sessions. Each request stands for its own.


### PR DESCRIPTION
This PR suggests some breaking changes for the ThingSet protocol which try to solve issues that occured during the development of gateways to map ThingSet with MQTT and HTTP.

Preview: [libre.solar/thingset/branch/v0.4/](https://libre.solar/thingset/branch/v0.4/)

## Non-breaking changes

### Nomenclature update

These updates try to enhance consistency and understanding of the protocol concepts.

- Data nodes are now called **data objects** (as it was already the case in a very early version of the protocol) in order to avoid confusion with IoT devices, which are also often called "nodes"
- Leaf nodes containing actual data (like `Bat_V`) are called **data items**.
- Publication messages are called statements. Statements are mainly used in a broadcasting fashion, but can also sent to a specific device in which case the device applies the stated data item values if possible. In contrast to request/response, no confirmation or error message is sent back after a statement has been received and processed.
- A data object referencing multiple other data items (array of their names) e.g. to specify the content of a statement is called **data set**.
- Executable data objects are prefixed with `x-` in order to distinguish them from paths or data sets.
- Internal data objects (prefixed with `.`) are introduced, which are used to configure e.g. the publication frequency of groups or data sets.

## Other updates/improvements

- The example data structure was changed, e.g. `output` group was split into `meas` and `state`. However, adapting this structure is not mandatory.
- Draft specification for LoRaWAN mapping added
- Draft specification for MQTT topic layout added

## Breaking changes

### Statements now contain the path

Previously, a binary publication message only contained the hash sign followed by the payload data. Published messages (now called statements) have been extended to contain the path, e.g. `meas`:
```
#meas {"Bat_V":14.4,"Ambient_degC":20}
```
This is necessary for better integration with MQTT. It allows to have separate topics for static data, dynamic measurement data and event-driven data, which can be sent in very different periods.

### GET requests in binary mode do not contain payload anymore

Previously, the payload behind the endpoint/path was used for device discovery (e.g. to get all data objects below a specific path or return name:value maps instead of id:value maps).

However, CoAP and HTTP requests do not allow any payload.

In order to make ThingSet more compatible, the FETCH request is used for device discovery instead.

### The `nameid` command in binary mode has been removed

Instead, ID / name mapping is done via normal data items stored under the fixed path `.names`. This allows for better compatibility with other protocols aswell.

### Some IDs are reserved

For LoRaWAN and CAN some IDs need to be known in advance in order to retrieve further device information. The IDs from `0x10` to `0x20` are now reserved for these purposes. In addition to that, IDs > `0x8000` are reserved for control purposes.
