### PR TITLE
Add method to fetch IDs from paths in binary mode

### DIFF
--- a/docs/spec/v0.5/appl_binary_mode.md
+++ b/docs/spec/v0.5/appl_binary_mode.md
@@ -48,13 +48,28 @@ The examples in this chapter are based on the same data structure as introduced 
 
 The firmware developer is free to choose the IDs.
 
-In contrast to the text mode, the binary mode has a special `"_path"` endpoint (ID `0x17`) that allows to retrieve the path for a given ID using a `FETCH` request.
+In contrast to the text mode, the binary mode has the special endpoints `"_ids"` (ID `0x16`) and `"_paths"` (ID `0x17`) that allow to retrieve the path for a given ID or vice versa using a `FETCH` request.
 
-**Example 1:** Request path of object IDs `0x40` and `0x41`
+**Example 1:** Request IDs of object paths `"Bat/rMeas_V"` and `"Bat/rMeas_A"`
 
     Request:
     05                                      # FETCH request
-       17                                   # CBOR uint: 0x17 (_path endpoint)
+       16                                   # CBOR uint: 0x17 (_ids endpoint)
+       82                                   # CBOR array (2 elements)
+          6B 4261742F724D6561735F56         # CBOR string: "Bat/rMeas_V"
+          6B 4261742F724D6561735F41         # CBOR string: "Bat/rMeas_A"
+
+    Response:
+    85                                      # Content.
+       82                                   # CBOR array (2 elements)
+          18 40                             # CBOR uint: 0x40 (object ID)
+          18 41                             # CBOR uint: 0x41 (object ID)
+
+**Example 2:** Request paths of object IDs `0x40` and `0x41`
+
+    Request:
+    05                                      # FETCH request
+       17                                   # CBOR uint: 0x17 (_paths endpoint)
        82                                   # CBOR array (2 elements)
           18 40                             # CBOR uint: 0x40 (object ID)
           18 41                             # CBOR uint: 0x41 (object ID)

--- a/docs/spec/v0.5/appl_data_structure.md
+++ b/docs/spec/v0.5/appl_data_structure.md
@@ -107,7 +107,8 @@ The following table shows the assigned IDs. Currently unassigned IDs might be de
 |------|--------------|------------------------------------------------------------------------|
 | 0x00 |              | Root object of a device                                                |
 | 0x10 | t_s          | Unix timestamp in seconds since Jan 01, 1970                           |
-| 0x17 | _path        | Endpoint used by binary protocol to determine paths from IDs           |
+| 0x16 | _ids         | Endpoint used by binary protocol to determine IDs from paths           |
+| 0x17 | _paths       | Endpoint used by binary protocol to determine paths from IDs           |
 | 0x18 | cMetadataURL | URL to JSON file containing extended information about exposed data    |
 | 0x1D | cNodeID      | Alphanumeric string (without spaces) to identify the device/node (should be unique per manufacturer, typical length 8 characters) |
 | >=0x8000 | ...      | Control data objects with fixed IDs                                    |
@@ -176,7 +177,14 @@ The following example data structure of an MPPT solar charge controller will be 
             "sPeriod_s": 10                                         // 0xF5
         }
     },
-    "_path": {                                                      // 0x17 (fixed)
+    "_ids": {                                                       // 0x16 (fixed)
+        "Device": 0,
+        "Bat": 2,
+        // ...
+        "Bat/rMeas_V": 64
+        // ...
+    },
+    "_paths": {                                                     // 0x17 (fixed)
         "0x01": "Device",
         "0x02": "Bat",
         // ...

--- a/docs/spec/v0.5/appl_text_mode.md
+++ b/docs/spec/v0.5/appl_text_mode.md
@@ -66,7 +66,7 @@ Only those data objects are returned which are at least readable. Thus, the resu
     :85 Content. ["t_s","cNodeID","cMetadataURL","Device","Bat","Solar","Load","eBoot",
     "eState","m","_pub"]
 
-Note that `_path` is not contained in the list, as it is only available in the binary mode.
+Note that `_ids` and `_paths` are not contained in the list, as they are only available in the binary mode.
 
 **Example 2:** Retrieve all content of `Bat` path (names + values)
 


### PR DESCRIPTION
So far, the spec only defined how to fetch paths for given IDs, but not other way round.

This is a proposal how to implement a method to get internal IDs by providing the path. It is meat for the binary mode only.

I'm working on the C implementation of the firmware already.

Remark: I thought about using a special endpoint like CBOR undefined instead of a new ID, but this would cause issues with the mapping to CoAP, where the path is usually a normal string and not binary data.

Ping @towen