### PR TITLE
Add specification for records to store arbitrary JSON data

### DIFF
--- a/docs/spec/v0.5/appl_binary_mode.md
+++ b/docs/spec/v0.5/appl_binary_mode.md
@@ -80,6 +80,19 @@ In contrast to the text mode, the binary mode has the special endpoints `"_ids"`
           6B 4261742F724D6561735F56         # CBOR string: "Bat/rMeas_V"
           6B 4261742F724D6561735F41         # CBOR string: "Bat/rMeas_A"
 
+**Example 3:** Request paths of object ID `0x70` (part of a record)
+
+    Request:
+    05                                      # FETCH request
+       17                                   # CBOR uint: 0x17 (_paths endpoint)
+       81                                   # CBOR array (1 element)
+          18 70                             # CBOR uint: 0x40 (object ID)
+
+    Response:
+    85                                      # Content.
+       81                                   # CBOR array (1 element)
+          67 4C6F672F745F73                 # CBOR string: "Log/t_s"
+
 ## Read data
 
 Similar to the text mode, the binary variants of the GET and FETCH functions also allow to read one or more data objects. The objects are identified by their parent object (endpoint of a path) and their IDs or their names.
@@ -177,9 +190,11 @@ If a path (string containing names) is used to specify an endpoint, also names a
 
 **Example 7:** Retrieve multiple data items:
 
+For fetching multiple data items, the IDs are provided in the array as the second argument. The endpoint (first argument) is redundant, as the ID already provides an unambiguous link to the data item, so it should be set to `0x00`.
+
     Request:
     05                                      # FETCH
-       02                                   # CBOR uint: 0x02 (parent ID)
+       00                                   # CBOR uint: 0x00 (root ID)
        82                                   # CBOR array (2 elements)
           18 40                             # CBOR uint: 0x40 (object ID)
           18 41                             # CBOR uint: 0x41 (object ID)
@@ -189,6 +204,49 @@ If a path (string containing names) is used to specify an endpoint, also names a
        82                                   # CBOR array (2 elements)
           FA 414E6666                       # CBOR float: 12.9
           FA C048F5C3                       # CBOR float: -3.14
+
+**Example 7:** Retrieve number of records in `Log`
+
+If the endpoint is an array of records, fetching `undefined` for discovery returns the number of elements in the array (i.e. number of records) instead of the names or IDs as in case of groups as endpoint.
+
+    Request:
+    05                                      # FETCH
+       08                                   # CBOR uint: 0x08 (parent ID)
+       F7                                   # CBOR undefined as a wildcard
+
+    Response:
+    85                                      # Content.
+       02                                   # CBOR uint: 0x02 (2 elements)
+
+**Example 8:** Retrieve first record in `Log`
+
+Records are always returned as key/value maps, similar to GET requests for groups.
+
+    Request:
+    05                                      # FETCH
+       08                                   # CBOR uint: 0x08 (parent ID)
+       00                                   # CBOR uint: 0x00 (index)
+
+    Response:
+    85                                      # Content.
+       A2                                   # CBOR map (2 elements)
+          18 70                             # CBOR uint: 0x70 (object ID)
+          1A 1B7561E0                       # CBOR uint: 460677600
+          18 71                             # CBOR uint: 0x71 (object ID)
+          19 0100                           # CBOR uint: 256
+
+**Example 9:** Attempt to retrieve a single item from a record in `Log`
+
+As there can be multiple instances of the same record sharing the same IDs for their items, it's not possible to query a record item by ID.
+
+    Request:
+    05                                      # FETCH
+       00                                   # CBOR uint: 0x00 (root ID)
+       82                                   # CBOR array (2 elements)
+          18 70                             # CBOR uint: 0x70 (object ID)
+
+    Response:
+    A4                                      # Not Found.
 
 ## Update data
 

--- a/docs/spec/v0.5/appl_data_structure.md
+++ b/docs/spec/v0.5/appl_data_structure.md
@@ -82,13 +82,14 @@ The data types of function parameters for executable items cannot be determined,
 
 #### Records
 
-It is not always feasible to statically assign IDs for data items at compile-time.
+It is not always feasible to statically assign IDs for all data items at compile-time:
 
-Records are a collection of arbitrary key/value pairs of data (JSON objects) stored as elements of an array. Only the array has an associated data object ID, where as the individual records can be accessed using their index in the array (starting at 0).
+- Where the data follows a pattern but the size of the pattern is not known in advance, e.g. log events, a modular system of N modules, or a multi-channel sensor/ADC input where each channel has the same configuration structure.
+- If a device is trying to expose data from one or more connected devices (i.e. a protocol bridge)
 
-This type of data structure can be used e.g. to log events, which may all have the same data structure, but you can have an unknown amount of events.
+Records are a collection of arbitrary key/value pairs of data (JSON objects) stored as elements of an array. The individual records can be accessed using their index in the array (starting at 0). Only entire records can be addressed. It is not possible to read or change individual items which are part of a record.
 
-Only entire records can be addressed. It is not possible to read or change individual items which are part of a record.
+The same items in different records share their IDs. This allows to use IDs instead of names in the binary protocol, but only the class/type of items has to be known in advance, not the number of items.
 
 It is not required that all records of one data object have the same data structure. However, using the same `struct` for all records would be most easy to implement for lower-level languages like C.
 
@@ -180,11 +181,11 @@ The following example data structure of an MPPT solar charge controller will be 
     },
     "Log": [                                                        // 0x08
         {                                                           // #0
-            "t_s": 460677000,
-            "rErrorFlags": 4
+            "t_s": 460677000,                                       // 0x70 (shared)
+            "rErrorFlags": 4                                        // 0x71 (shared)
         },{                                                         // #1
-            "t_s": 460671000,
-            "rErrorFlags": 256
+            "t_s": 460671000,                                       // 0x70 (shared)
+            "rErrorFlags": 256                                      // 0x71 (shared)
         }
     ],
     "eBoot": ["cMetadataURL", "Device/cFirmwareCommit"],            // 0x05
@@ -204,14 +205,20 @@ The following example data structure of an MPPT solar charge controller will be 
         "Device": 0,
         "Bat": 2,
         // ...
-        "Bat/rMeas_V": 64
+        "Bat/rMeas_V": 64,
+        // ...
+        "Log/t_s": 112,
+        "Log/ErrorFlags": 113
         // ...
     },
     "_paths": {                                                     // 0x17 (fixed)
         "0x01": "Device",
         "0x02": "Bat",
         // ...
-        "0x40": "Bat/rMeas_V"
+        "0x40": "Bat/rMeas_V",
+        // ...
+        "0x70": "Log/t_s",
+        "0x71": "Log/ErrorFlags",
         // ...
     }
 }

--- a/docs/spec/v0.5/appl_data_structure.md
+++ b/docs/spec/v0.5/appl_data_structure.md
@@ -80,6 +80,20 @@ The data types of function parameters for executable items cannot be determined,
 | b      | binary data (base-64 encoded)                 |
 | u      | utf8-string                                   |
 
+#### Records
+
+It is not always feasible to statically assign IDs for data items at compile-time.
+
+Records are a collection of arbitrary key/value pairs of data (JSON objects) stored as elements of an array. Only the array has an associated data object ID, where as the individual records can be accessed using their index in the array (starting at 0).
+
+This type of data structure can be used e.g. to log events, which may all have the same data structure, but you can have an unknown amount of events.
+
+Only entire records can be addressed. It is not possible to read or change individual items which are part of a record.
+
+It is not required that all records of one data object have the same data structure. However, using the same `struct` for all records would be most easy to implement for lower-level languages like C.
+
+Data objects to store records don't have a prefix. Their name is similar to a group. The difference is that records are wrapped in an array of arbitrary length and not directly stored as key/value pairs in a JSON object.
+
 ### Units
 
 Only [SI units](https://en.wikipedia.org/wiki/International_System_of_Units) and derived units (e.g. kWh for energy instead of Ws) are allowed.
@@ -164,6 +178,15 @@ The following example data structure of an MPPT solar charge controller will be 
         "r_W": 137.0,                                               // 0x61
         "pTotal_kWh": 1789                                          // 0x62
     },
+    "Log": [                                                        // 0x08
+        {                                                           // #0
+            "t_s": 460677000,
+            "rErrorFlags": 4
+        },{                                                         // #1
+            "t_s": 460671000,
+            "rErrorFlags": 256
+        }
+    ],
     "eBoot": ["cMetadataURL", "Device/cFirmwareCommit"],            // 0x05
     "eState": ["t_s", "Device/rErrorFlags"],                        // 0x06
     "m": ["t_s", "Bat/rMeas_V", "Solar/r_W", "Load/r_W"],           // 0x07

--- a/docs/spec/v0.5/appl_text_mode.md
+++ b/docs/spec/v0.5/appl_text_mode.md
@@ -83,6 +83,16 @@ Note that `_ids` and `_paths` are not contained in the list, as they are only av
     ?Bat ["rMeas_V"]
     :85 Content. [12.9]
 
+**Example 5:** Retrieve number of records in `Log`
+
+    ?Log/
+    :85 Content. 2
+
+**Example 6:** Retrieve first record in `Log`
+
+    ?Log/0
+    :85 Content. {"t_s":460677000,"rErrorFlags":4}
+
 ## Update data
 
 The PATCH request attempts to overwrite the values of data items.


### PR DESCRIPTION
Records would allow to define repeating data structures more efficiently, e.g. for:

- Logging events
- Multiple objects of the same type (e.g. battery modules in a BMS with multiple cell voltages and a temperature sensor each)

The following branch contains a WIP implementation in the C library: https://github.com/ThingSet/thingset-device-library/tree/record-support