### PR TITLE
CAN bus: Add automatic node address assignment

### DIFF
--- a/docs/spec/v0.5/transp_can.md
+++ b/docs/spec/v0.5/transp_can.md
@@ -10,19 +10,14 @@ The CAN bus part of the ThingSet protocol is still in an early stage and may cha
 
 This specification defines layer 3 (Network) and 4 (Transport) of the ThingSet Protocol via CAN bus. Layer 1 and 2 are provided by the CAN bus itself.
 
-Only the binary messages of the ThingSet Protocol are supported via CAN.
-
 ## General features
 
 - Master-less operation
-- Automatic node ID assignment
+- Automatic node ID assignment without central instance
 - Efficient useage of CAN ID and data bytes
 - Transport protocol to allow payload of more than 8 bytes
-- Two different types of messages for application layer
-    - Service message (request/response)
-    - Publication message (publish/subscribe)
 - RTR frame is not allowed
-- Fixed bitrate of 250 kbit
+- Fixed bitrate of 500 kbit/s
 
 ### CAN identifier layout
 
@@ -30,26 +25,43 @@ In the CAN bus, the identifier part of the CAN frame is used for arbitration and
 
 For a network with connected ThingSet devices, the layout of the CAN identifier is similar to the SAE J1939 specification. Parts of the identifier define the source and destination address of the message. In addition to that, the first three bits are used to prioritize the messages.
 
-Two general types of messages are specified: Service message and publication message. Only CAN extended IDs with a size of 29 bit are used.
+The node address can be in the range of `0x00` to `0xFD` (253). Node addresses `0xFE` and `0xFF` are reserved for network management purposes (see below).
 
-## Service message
+| Bits | 28 .. 26 | 25 .. 24 |    23 .. 16   |    15 .. 8    |     7 .. 0     |
+|------|:--------:|:--------:|:-------------:|:-------------:|:--------------:|
+|      | Priority |   Type   | Variable byte | Variable byte | Source address |
 
-A service message is used for the request/response messaging pattern. A single byte each for source and destination node address are defined as part of the CAN ID to identify sender and receiver of the message.
+There are three different message types defined for ThingSet:
+
+- `0x0`: [Service message (request/response)](#request-response)
+- `0x2`: [Publication message (publish/subscribe)](#publish-subscribe)
+- `0x3`: [Network management message](#network-management)
+
+The variable bytes have a different meaning depending on the message type.
+
+It may be possible to run ThingSet messages on the same bus with SAE J1939 (using type `0x0`) or NMEA2000 (using type `0x1`) if device addresses are chosen carefully. However, ThingSet is not meant to be compatible with mentioned protocols.
+
+Only CAN extended IDs with a size of 29 bit are used, so it should be possible to use ThingSet together with protocols using standard IDs (e.g. CANopen) on the same bus.
+
+## Request/response
+
+A service message can be identified by the type bits 25-24 both set to 0. A single byte each for source and destination node address are defined as part of the CAN ID to identify sender and receiver of the message.
+
+A service message can be routed to different physical buses by a gateway. The bus number is also encoded as part of the CAN ID.
 
 ### CAN identifier layout
 
 The service message addressing in 29-bit CAN ID is similar to SAE J1939:
 
-| Bits | 28 .. 26 | 25 | 24 |    23 .. 16     |   15 .. 8      |   7 .. 0       |
-|------|:--------:|:--:|:--:|:---------------:|:--------------:|:--------------:|
-|      | Priority | 1  | 0  | reserved (0xDA) | Target address | Source address |
+| Bits |     28 .. 26    |   25 .. 24  |    23 .. 16     |   15 .. 8      |   7 .. 0       |
+|------|:---------------:|:-----------:|:---------------:|:--------------:|:--------------:|
+|      | Priority: `0x6` | Type: `0x0` |   Bus number    | Target address | Source address |
 
-- Priority (28-26): Defines the importance of the message. For service messages, only 3 (high priority) or 7 (low priority) are valid.
-- Extended data page / EDP (25): Always 1b to prevent collision with SAE J1939 and NMEA2000 devices on the same bus
-- Message type (24): 0b for service message
-- Reserved (23-16): Set to 218 (0xDA) as suggested by ISO-TP standard (ISO 15765-2) for normal fixed addressing with N_TAtype = physical
-- Target address (15-8): Destination node address
-- Source address (7-0): Source node address (255 for anonymous message during address claiming)
+- Priority (28-26): Defines the importance of the message. For service messages, only priority 6 is valid.
+- Type (25-24): 0x0 for request/response message
+- Bus number (23-16): Default for single bus systems is `0xDA` (218) as suggested by ISO-TP standard (ISO 15765-2) for normal fixed addressing with N_TAtype = physical
+- Target address (15-8): Destination node address (`0x00` to `0xFD`)
+- Source address (7-0): Source node address (`0x00` to `0xFD`)
 
 ### Transport protocol (ISO 15765-2)
 
@@ -150,23 +162,22 @@ Subsequent frames:
 - Byte 2-8: 7 bytes of transmitted data. Unused bits in the last frame of a fast-packet message shall be filled with "1" bits.
 -->
 
-## Publication message
+## Publish/subscribe
 
-The publication message provides a very efficient way to send data in a regular interval using a single CAN frame without the overhead of a transport protocol. The publication messages are mainly intended for monitoring purposes.
+The publication message provides a very efficient way to send data in a regular interval using a single CAN frame without the overhead of a transport protocol. The publication messages are mainly intended for monitoring purposes. The first type bit is set to `1` (resulting in `0x2`).
 
 ### CAN identifier layout
 
 Publication messages are not sent to a single node, so the destination address does not need to be specified. Instead, the data object ID is specified directly in the CAN identifier to have more bytes available for payload in the data section of the CAN frame.
 
-| Bits | 28 .. 26 | 25 | 24 |   23 .. 16         |   15 .. 8          |   7 .. 0       |
-|------|:--------:|:--:|:--:|:------------------:|:------------------:|:--------------:|
-|      | Priority | 1  | 1  | Data object ID (MSB) | Data object ID (LSB) | Source address |
+| Bits | 28 .. 26 |   25 .. 24  |    23 .. 16          |   15 .. 8            |   7 .. 0       |
+|------|:--------:|:-----------:|:--------------------:|:--------------------:|:--------------:|
+|      | Priority | Type: `0x2` | Data object ID (MSB) | Data object ID (LSB) | Source address |
 
-- Priority (28-26): Defines the importance of the message. For publication messages, only 4 (high priority), 5 (medium priority) and 6 (low priority) are valid.
-- Extended data page / EDP (25): Always 1b to prevent collision with SAE J1939 and NMEA2000 devices on the same bus
-- Message type (24): 1b for publication message
+- Priority (28-26): Defines the importance of the message. For publication messages, only 5 (high priority) and 7 (low priority) are valid.
+- Type (25-24): `0x2` for publication message
 - Data object ID (23-8): Data object ID as a 16-bit unsigned integer. The most significant byte is stored first (bits 23 to 16).
-- Source address (7-0): Source node address (255 for anonymous message during address claiming)
+- Source address (7-0): Source node address (`0x00` to `0xFD`)
 
 The data object ID is not encoded in the CBOR format, but as a raw 16-bit unsigned integer. The publication messages are limited to IDs that fit into 16 bits.
 
@@ -179,6 +190,104 @@ The data section of the CAN frame contains the CBOR-encoded value of the data ob
 In order to acquire real-time measurement values, a 16-bit timestamp (unsigned int) can be appended to the CBOR-encoded value. The timestamp contains the 16 least significant bits of the microcontroller's system clock in milliseconds. It is a rolling counter and restarts at 0 after an overflow. The timestamp cannot be used to determine the absolute time of a measurement, but the time difference between subsequent measurements. This is important to obtain correct sampling of time-series data if higher priority messages cause a delay of the data delivery on the bus.
 
 The maximum length of the value and the optional timestamp is defined by the maximum data section size of the CAN frame (8 bytes for classic CAN).
+
+## Network management
+
+The network management is handled using dedicated CAN frames with type `0x3`. These frames are mainly used for automatic CAN address assignment.
+
+The required features of the CAN address assignment are:
+
+- No central instance to assign addresses (unlike for e.g. DHCP)
+- Nodes must re-claim their address:
+  - After start-up
+  - After bus disconnects
+- Avoid error frames as much as possible
+- Reduce bus traffic as much as possible
+- Have all addresses assigned within <1s for >99% of the use cases
+
+Critical scenarios for testing:
+
+- All nodes (max. 253) on the same bus are powered up simultaneously.
+- A node is connected to an an already operating network (hot-plugging) and should not disturb operation.
+
+### Description of the approach
+
+The dynamic address assignment protocol requires two dedicated frames: The **Address Discovery frame** and the **Address Claim frame**.
+
+Dynamic address assignment capability is mandatory for each node. The nodes may have a preferred default address (e.g. manually assigned during production or based on previous successful address claims) to speed up the network start-up, but they must be able to change the address to a random number if it is already taken by another node.
+
+#### Address Discovery frame
+
+This frame is used to find out if a desired address is already taken by another node on the bus. It is sent out immediately after start-up or after re-connection to the bus.
+
+| Bits |     28 .. 26    |   25 .. 24  |   23 .. 16  |   15 .. 8      |        7 .. 0          |
+|------|:---------------:|:-----------:|:-----------:|:--------------:|:----------------------:|
+|      | Priority: `0x4` | Type: `0x3` | Random data | Target address | Source address: `0xFE` |
+
+- Priority (28-26): `0x4` suggested for network management frames
+- Type (25-24): `0x3` for network management frames
+- Random data (23-16): Used to select between two nodes attempting to discover an address at the same time
+- Target address (15-8): Desired node address (`0x00` to `0xFD`)
+- Source address (7-0): `0xFE` for anonymous address
+- Payload: None (DLC set to 0)
+
+The target address is the desired address of the node. If this address is already taken, the node with that address must immediately respond with an Address Claim frame (see below).
+
+The random number in the CAN ID provides a first level of protection against collision of different nodes wanting to claim the same address. If another node with higher priority random number tries to claim the same address at the same time it will win the arbitration on the bus. The message will be received and the node has to try again with another address.
+
+#### Address Claim frame
+
+This frame indicates that the device with the EUI-64 in the payload uses the given source address.
+
+| Bits |    28 .. 26     |   25 .. 24  |   23 .. 16  |        15 .. 8         |     7 .. 0     |
+|------|:---------------:|:-----------:|:-----------:|:----------------------:|:--------------:|
+|      | Priority: `0x4` | Type: `0x3` |  Bus number | Target address: `0xFF` | Source address |
+
+- Priority (28-26): `0x4` suggested for network management frames
+- Type (25-24): `0x3` for network management frames
+- Bus number (23-16): same as for request/response messages
+- Target address (15-8): `0xFF` for broadcast without a specific recipient
+- Source address (7-0): Source node address being claimed (`0x00` to `0xFD`)
+- Payload: 8-byte EUI-64 of the node
+
+The EUI-64 in the payload is required to resolve potential conflicts (see below) and can be used by other devices to keep track of the devices connected to the bus.
+
+#### Overview of address assignment process
+
+The following steps are necessary after power-up of the node or after bus re-connection:
+
+1. The node determines its desired address (random or previously used, e.g. read from EEPROM) and adds a CAN filter for incoming frames for this address.
+2. The node sends out an address discovery frame.
+3. If no other node responded with an address claim frame within a given timeout (e.g. 500 ms, t.b.d.), the node assumes it can use the address. Otherwise it restarts from step 1 with a new random address.
+4. The node sends out an address claim frame with its new address.
+
+The node should only send out any data (e.g. publication messages) after the address assignment process has successfully finished.
+
+For the very unlikely case that two nodes chose the same address, generated the same random number in the address discovery frame and sent out the address claim frame at exactly the same time, the non-matching EUI-64 payload will result in an error frame on the bus, in which case both devices have to repeat the overall process with a new random address.
+
+### Considered alternatives
+
+#### DHCP
+
+Relies on a central instance to assign addresses, which is not desired for this application.
+
+#### SAE J1939
+
+Uses a similar address claiming mechanism as described above, but without the initial step of address discovery. This leads to a higher probability of error frames because of collisions.
+
+Further reading: [here](https://copperhilltech.com/blog/sae-j1939-address-claim-procedure-sae-j193981-network-management/) and [here](https://copperhilltech.com/blog/sae-j1939-network-management-and-address-claim-procedure/)
+
+#### UAVCAN / OpenCyphal
+
+Rather complicated algorithm with special UAVCAN messages, which is not directly applicable.
+
+Further reading: [Specification](https://opencyphal.org/specification/Cyphal_Specification.pdf)
+
+#### 6LoCAN
+
+Uses similar mechanism with random data in the CAN ID to avoid error frames, but uses RTR frames, which are discouraged.
+
+Further reading: [IETF draft](https://datatracker.ietf.org/doc/html/draft-wachter-6lo-can-00#section-3)
 
 ## Physical layer
 


### PR DESCRIPTION
The node addresses (used in the source and target bytes) had to be hard-coded so far. This commit introduces a an automatic node address assignment process, which is similar to SAE J1939 address claiming with some improvements to reduce collisions.

For efficient implementation in the firmware it is required to have a dedicated CAN frame type for network management whose IDs don't overlap with existing req/resp and pub/sub frames. For this reason, another variant defined by the DP and EDP bits from SAE J1939 had to be used.

The previous approach was to select bits which are currently not used by SAE J1939 or NMEA2000. However, this would only leave 2 message types for ThingSet.

As ThingSet uses 500 kbit/s as its fixed bitrate, which is incompatible with above mentioned standards anyway, it was decided to drop the idea of allowing to use the same bus for different standards and use the SAE J1939 CAN ID space for ThingSet request/response messages.

It may actually still be possible to share a bus between ThingSet and SAE J1939 after the node addresses have been assigned, but it's not a goal of the ThingSet protocol (anymore) and the protocol will not be constrained in order to support this.

This PR puts RFC #22 in practice (with some additional modifications).